### PR TITLE
refactor: update ui for import and backup modals

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import {
 	Text,
@@ -16,6 +16,7 @@ const Button = ({
 	style = {},
 	textStyle = {},
 	activeOpacity = 0.7,
+	disabled = false,
 }: {
     text: string;
     loading?: boolean;
@@ -26,14 +27,16 @@ const Button = ({
     style?: object;
     textStyle?: object;
 	activeOpacity?: number;
+	disabled?: boolean;
 }): React.ReactElement => {
+	const disabledStyle = useMemo(() => (disabled || loading ? styles.disabled : null), [disabled, loading]);
 	return (
 		<ActionButton
-			style={[styles.actionButton, style]}
+			style={[styles.actionButton, disabledStyle, style]}
 			onPress={onPress}
 			onPressIn={onPressIn}
 			onLongPress={onLongPress}
-			disabled={loading}
+			disabled={loading || disabled}
 			activeOpacity={activeOpacity}
 		>
 			{loading ? (<ActivityIndicator size="small" />) : (
@@ -56,6 +59,9 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 24,
 		alignContent: 'center',
 		justifyContent: 'center',
+	},
+	disabled: {
+		opacity: 0.5,
 	},
 	actionButtonText: {
 		fontSize: 15,

--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -222,15 +222,15 @@ const styles = StyleSheet.create({
 		alignSelf: 'center',
 	},
 	indicator: {
-		width: 40,
+		width: 32,
 		height: 4,
 		backgroundColor: '#ccc',
 		borderRadius: 2,
-		marginTop: 8,
-		marginBottom: 8,
+		marginVertical: 12,
 	},
 	content: {
-		padding: 24,
+		paddingHorizontal: 24,
+		paddingBottom: 24,
 	},
 	section: {
 		marginBottom: 24,

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -21,6 +21,7 @@ import {
 	ArrowRight,
 	CardView,
 } from '../theme/components.ts';
+import { truncatePubky } from '../utils/pubky.ts';
 
 const Jdenticon = ({
 	value,
@@ -53,13 +54,6 @@ interface PubkyBoxProps {
   onPress: (data: string) => void;
   index: number;
 }
-
-const truncatePubky = (pubky: string): string => {
-	if (pubky.length <= 16) {
-		return pubky;
-	}
-	return `${pubky.substring(0, 5)}...${pubky.substring(pubky.length - 5)}`;
-};
 
 const PubkyBox = ({
 	pubky,

--- a/src/components/PubkyDetail/PubkyDetail.tsx
+++ b/src/components/PubkyDetail/PubkyDetail.tsx
@@ -79,8 +79,7 @@ export const PubkyDetail = ({
 				Alert.alert('Error', 'Could not retrieve secret key for backup');
 				return;
 			}
-
-			showBackupPrompt(secretKeyResponse.value);
+			showBackupPrompt({ secretKey: secretKeyResponse.value, pubky });
 
 		} catch (error) {
 			console.error('Backup process error:', error);

--- a/src/components/PubkyDetail/PubkyListHeader.tsx
+++ b/src/components/PubkyDetail/PubkyListHeader.tsx
@@ -36,6 +36,7 @@ export const PubkyListHeader = memo(({
 	svg,
 	pubky,
 	pubkyData,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	sessionsCount,
 	onQRPress,
 	onCopyClipboard,

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -52,17 +52,16 @@ const styles = StyleSheet.create({
 		height: '98%',
 	},
 	cameraContainer: {
-		height: '98%',
+		height: '96%',
 		borderTopLeftRadius: 20,
 		borderTopRightRadius: 20,
 	},
 	indicator: {
-		width: 40,
+		width: 32,
 		height: 4,
 		backgroundColor: '#ccc',
 		borderRadius: 2,
-		marginTop: 8,
-		marginBottom: 8,
+		marginVertical: 12,
 	},
 });
 

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -11,6 +11,7 @@ import {
 	Edit2 as _Edit2,
 	Trash2 as _Trash2,
 	Save as _Save,
+	KeyRound as _KeyRound,
 } from 'lucide-react-native';
 import ActionSheet from 'react-native-actions-sheet';
 
@@ -164,5 +165,9 @@ export const Eye = styled(_Eye)`
 `;
 
 export const EyeOff = styled(_EyeOff)`
+  color: ${(props): string => props.theme.colors.sessionText};
+`;
+
+export const KeyRound = styled(_KeyRound)`
   color: ${(props): string => props.theme.colors.sessionText};
 `;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -107,13 +107,19 @@ export const generateBackupFileName = (prefix: string = 'pubky-backup'): string 
 };
 
 
-export const showBackupPrompt = (
+export const showBackupPrompt = ({
+	secretKey,
+	pubky,
+	onComplete,
+}: {
 	secretKey: string,
+	pubky: string,
 	onComplete?: () => void
-): void => {
+}): void => {
 	SheetManager.show('backup-prompt', {
 		payload: {
 			viewId: EBackupPromptViewId.backup,
+			pubky,
 			onSubmit: async (passphrase: string) => {
 				try {
 					const createRecoveryFileRes = await createRecoveryFile(

--- a/src/utils/pubky.ts
+++ b/src/utils/pubky.ts
@@ -201,3 +201,10 @@ export const signOutOfHomeserver = async (pubky: string, sessionPubky: string, d
 	dispatch(setSignedUp({ pubky, signedUp: false }));
 	dispatch(removeSession({ pubky, sessionPubky }));
 };
+
+export const truncatePubky = (pubky: string): string => {
+	if (pubky.length <= 16) {
+		return pubky;
+	}
+	return `${pubky.substring(0, 5)}...${pubky.substring(pubky.length - 5)}`;
+};

--- a/src/utils/rnfs.ts
+++ b/src/utils/rnfs.ts
@@ -110,9 +110,15 @@ export async function importFile(dispatch: Dispatch): Promise<Result<string>> {
 			return err('Please select a .pkarr file');
 		}
 
+		const fileName = file.name;
+
 		const base64Content = await RNFS.readFile(filePath, 'base64');
+		const fileStats = await RNFS.stat(filePath);
+
 
 		return showImportPrompt({
+			fileName: fileName ?? '',
+			fileDate: fileStats.mtime,
 			content: base64Content,
 			dispatch,
 		});
@@ -126,10 +132,22 @@ export async function importFile(dispatch: Dispatch): Promise<Result<string>> {
 	}
 }
 
-export const showImportPrompt = ({ content, dispatch }: { content: string; dispatch: Dispatch }): Promise<Result<string>> => {
+export const showImportPrompt = ({
+	fileName,
+	fileDate,
+	content,
+	dispatch,
+}: {
+	fileName: string;
+	fileDate: Date;
+	content: string;
+	dispatch: Dispatch
+}): Promise<Result<string>> => {
 	return new Promise((resolve) => {
 		SheetManager.show('backup-prompt', {
 			payload: {
+				fileName,
+				fileDate,
 				viewId: EBackupPromptViewId.import,
 				onSubmit: async (passphrase: string) => {
 					try {


### PR DESCRIPTION
This PR:
- Applies UI updates to the import and backup modal.
- Adds `disabled` prop to `Button` component.
- Adds `KeyRound` to styled components.
- Updates `showBackupPrompt` & `showImportPrompt` methods.



![Simulator Screenshot - iPhone 15 Pro Max - 2024-12-30 at 15 49 16](https://github.com/user-attachments/assets/607415d9-76c2-48d4-9b03-fb693ddb2ada)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-12-30 at 15 48 58](https://github.com/user-attachments/assets/91c64233-3c49-40e0-9690-2411a90e5d11)
