### PR TITLE
feat: add settings menu

### DIFF
--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -21,22 +21,28 @@ import {
 } from '../theme/components.ts';
 import { truncatePubky } from '../utils/pubky.ts';
 import Jdenticon from './Jdenticon.tsx';
+import { Result } from '@synonymdev/result';
 
 interface PubkyBoxProps {
   pubky: string;
   pubkyData: Pubky;
   sessionsCount?: number;
-  onQRPress: (
-    pubky: string,
-    pubkyData: Pubky,
-    dispatch: Dispatch,
-    onComplete?: () => void,
-  ) => Promise<string>;
-  onCopyClipboard: (
-    pubky: string,
-    pubkyData: Pubky,
-    dispatch: Dispatch,
-  ) => void;
+  onQRPress: ({
+	  pubky,
+	  dispatch,
+	  onComplete,
+  }: {
+	  pubky: string,
+	  dispatch: Dispatch,
+	  onComplete?: () => void,
+  }) => Promise<string>;
+  onCopyClipboard: ({
+	  pubky,
+	  dispatch,
+  }: {
+	  pubky: string,
+	  dispatch: Dispatch,
+  }) => Promise<Result<string>>;
   onPress: (data: string) => void;
   index: number;
 }
@@ -57,20 +63,23 @@ const PubkyBox = ({
 	const handleQRPress = useCallback(async () => {
 		setIsQRLoading(true);
 		try {
-			await onQRPress(pubky, pubkyData, dispatch);
+			await onQRPress({
+				pubky,
+				dispatch,
+			});
 		} finally {
 			setIsQRLoading(false);
 		}
-	}, [dispatch, onQRPress, pubky, pubkyData]);
+	}, [dispatch, onQRPress, pubky]);
 
 	const handleCopyClipboard = useCallback(async () => {
 		setIsClipboardLoading(true);
 		try {
-			onCopyClipboard(pubky, pubkyData, dispatch);
+			await onCopyClipboard({ pubky, dispatch });
 		} finally {
 			setIsClipboardLoading(false);
 		}
-	}, [dispatch, onCopyClipboard, pubky, pubkyData]);
+	}, [dispatch, onCopyClipboard, pubky]);
 
 	const handleOnPress = useCallback(() => {
 		onPress(pubky);

--- a/src/components/PubkyDetail/PubkyDetail.tsx
+++ b/src/components/PubkyDetail/PubkyDetail.tsx
@@ -18,8 +18,26 @@ import { useNavigation } from '@react-navigation/native';
 
 export interface PubkyDetailProps {
     pubkyData: PubkyData;
-    onQRPress: (pubky: string, pubkyData: Pubky, dispatch: Dispatch, onComplete?: () => void) => Promise<string>
-    onCopyClipboard: (pubky: string, pubkyData: Pubky, dispatch: Dispatch) => Promise<Result<string>>
+	onQRPress: ({
+		pubky,
+		pubkyData,
+		dispatch,
+		onComplete,
+	}: {
+		pubky: string,
+		pubkyData: Pubky,
+		dispatch: Dispatch,
+		onComplete?: () => void,
+	}) => Promise<string>;
+    onCopyClipboard: ({
+    	pubky,
+    	pubkyData,
+    	dispatch,
+    }: {
+		pubky: string;
+		pubkyData: Pubky;
+		dispatch: Dispatch;
+	}) => Promise<Result<string>>
 }
 
 export const PubkyDetail = ({
@@ -34,11 +52,11 @@ export const PubkyDetail = ({
 	const navigation = useNavigation();
 
 	const handleQRPress = useCallback(() => {
-		return onQRPress(pubky, pubkyData, dispatch);
+		return onQRPress({ pubky, pubkyData, dispatch });
 	}, [dispatch, onQRPress, pubky, pubkyData]);
 
 	const handleCopyClipboard = useCallback(async () => {
-		return onCopyClipboard(pubky, pubkyData, dispatch);
+		return onCopyClipboard({ pubky, pubkyData, dispatch });
 	}, [dispatch, onCopyClipboard, pubky, pubkyData]);
 
 	const onDelete = useCallback(async () => {

--- a/src/components/PubkyRingHeader..tsx
+++ b/src/components/PubkyRingHeader..tsx
@@ -1,9 +1,14 @@
 import { Image, StyleSheet } from 'react-native';
-import React, { memo, ReactElement, useCallback } from 'react';
+import React, { memo, ReactElement, useCallback, useRef } from 'react';
 import { TouchableOpacity, View } from '../theme/components.ts';
 import { toggleTheme as _toggleTheme } from '../theme/helpers.ts';
 import { useDispatch, useSelector } from 'react-redux';
 import { getTheme } from '../store/selectors/settingsSelectors.ts';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/types';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
 const PubkyRingHeader = ({
 	leftButton = undefined,
@@ -14,10 +19,22 @@ const PubkyRingHeader = ({
 }): ReactElement => {
 	const dispatch = useDispatch();
 	const theme = useSelector(getTheme);
+	const navigation = useNavigation<NavigationProp>();
+	const lastTapRef = useRef(0);
 
 	const toggleTheme = useCallback(() => {
 		_toggleTheme({ dispatch, theme });
 	}, [theme, dispatch]);
+
+	const handleDoubleTap = useCallback((): void => {
+		const now = Date.now();
+		const DOUBLE_TAP_DELAY = 300;
+
+		if (now - lastTapRef.current < DOUBLE_TAP_DELAY) {
+			navigation.navigate('Settings');
+		}
+		lastTapRef.current = now;
+	}, [navigation]);
 
 	return (
 		<View style={styles.container}>
@@ -25,6 +42,7 @@ const PubkyRingHeader = ({
 			<TouchableOpacity
 				activeOpacity={1}
 				onLongPress={toggleTheme}
+				onPress={handleDoubleTap}
 				style={styles.logoWrapper}
 			>
 				<Image

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -12,6 +12,7 @@ import { useSelector } from 'react-redux';
 import {
 	getShowOnboarding,
 } from '../store/selectors/settingsSelectors.ts';
+import SettingsScreen from '../screens/SettingsScreen.tsx';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -54,6 +55,14 @@ const RootNavigator = (): ReactElement => {
 						title: 'Pubky Ring',
 						gestureEnabled: false,
 						headerBackVisible: false,
+					}}
+				/>
+				<Stack.Screen
+					name="Settings"
+					component={SettingsScreen}
+					options={{
+						title: 'Settings',
+						gestureEnabled: true,
 					}}
 				/>
 				<Stack.Screen

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -8,6 +8,7 @@ export type RootStackParamList = {
   Onboarding: undefined;
   ConfirmPubky: undefined;
   Home: undefined;
+  Settings: undefined;
   PubkyDetail: {
     pubky: string;
   };

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -24,7 +24,7 @@ import {
 	View,
 	Plus,
 } from '../theme/components.ts';
-import { RootState } from '../store';
+import { RootState } from '../types';
 import PubkyRingHeader from '../components/PubkyRingHeader..tsx';
 import Button from '../components/Button.tsx';
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,175 @@
+import React, { memo, ReactElement, useCallback, useMemo, useState } from 'react';
+import { StyleSheet, Switch } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/types';
+import {
+	View,
+	Text,
+	ChevronLeft,
+	NavButton,
+	Card,
+	ActionButton,
+	SessionText,
+} from '../theme/components.ts';
+import PubkyRingHeader from '../components/PubkyRingHeader..tsx';
+import { useDispatch, useSelector } from 'react-redux';
+import { getAutoAuth, getTheme } from '../store/selectors/settingsSelectors.ts';
+import { setTheme } from '../theme/helpers.ts';
+import { ETheme } from '../types/settings.ts';
+import { updateAutoAuth } from '../store/slices/settingsSlice.ts';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'EditPubky'>;
+
+const SettingsScreen = ({ navigation }: Props): ReactElement => {
+	const dispatch = useDispatch();
+	const currentTheme = useSelector(getTheme);
+	const autoAuth = useSelector(getAutoAuth);
+	const [enableAutoAuth, setEnableAutoAuth] = useState(autoAuth);
+
+	const leftButton = useCallback(() => (
+		<NavButton
+			style={styles.navButton}
+			onPressIn={navigation.goBack}
+		>
+			<ChevronLeft size={16} />
+		</NavButton>
+	), [navigation]);
+
+	const rightButton = useCallback(() => (
+		<NavButton style={styles.rightNavButton} />
+	),[]);
+
+	const getThemeDisplayText = useCallback((theme: ETheme) => {
+		const themeText = {
+			[ETheme.system]: 'System',
+			[ETheme.light]: 'Light',
+			[ETheme.dark]: 'Dark',
+		};
+		return themeText[theme] || 'System';
+	}, []);
+
+	const themeDisplayText = useMemo(() => getThemeDisplayText(currentTheme), [currentTheme, getThemeDisplayText]);
+
+	const handleThemePress = useCallback(() => {
+		switch (currentTheme) {
+			case ETheme.system:
+				setTheme({ dispatch, theme: ETheme.light });
+				break;
+			case ETheme.light:
+				setTheme({ dispatch, theme: ETheme.dark });
+				break;
+			case ETheme.dark:
+				setTheme({ dispatch, theme: ETheme.system });
+				break;
+		}
+	}, [currentTheme, dispatch]);
+
+	const handleAutoAuthToggle = useCallback(() => {
+		dispatch(updateAutoAuth({ autoAuth: !enableAutoAuth }));
+		setEnableAutoAuth(prev => !prev);
+	}, [dispatch, enableAutoAuth]);
+
+	// const handleBackupPress = useCallback(() => {
+	// 	// Backup implementation to be added
+	// 	console.log('Backup all pubkys');
+	// }, []);
+
+	return (
+		<View style={styles.container}>
+			<PubkyRingHeader leftButton={leftButton()} rightButton={rightButton()} />
+
+			<View style={styles.content}>
+				<Card style={styles.section}>
+					<ActionButton onPress={handleThemePress} style={styles.themeButton}>
+						<Text style={styles.settingTitle}>Theme</Text>
+						<SessionText style={styles.themeValue}>
+							{themeDisplayText}
+						</SessionText>
+					</ActionButton>
+				</Card>
+
+				<Card style={styles.section}>
+					<View style={styles.toggleRow}>
+						<Text style={styles.settingTitle}>Auto Auth</Text>
+						<Switch
+							value={enableAutoAuth}
+							onValueChange={handleAutoAuthToggle}
+						/>
+					</View>
+				</Card>
+
+				{/* Backup all pubkys */}
+				{/* TODO: Consider implementing a "Backup All Pubkys" feature. Backs up all pubkys with same passphrase and saves as zip file for future import
+				<Card style={styles.section}>
+					<ActionButton
+						onPress={handleBackupPress}
+						style={styles.backupButton}
+					>
+						<Text style={styles.settingTitle}>Backup All Pubkys</Text>
+					</ActionButton>
+				</Card>
+				*/}
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		padding: 16,
+	},
+	rightNavButton: {
+		width: 32,
+		height: 32,
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'center',
+		backgroundColor: 'transparent',
+	},
+	navButton: {
+		width: 32,
+		height: 32,
+		borderRadius: 20,
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'center',
+		shadowColor: '#000',
+		shadowOffset: {
+			width: 0,
+			height: 2,
+		},
+		shadowOpacity: 0.25,
+		shadowRadius: 3.84,
+		elevation: 5,
+	},
+	section: {
+		marginBottom: 16,
+		borderRadius: 16,
+		overflow: 'hidden',
+	},
+	settingTitle: {
+		fontSize: 17,
+		fontWeight: '600',
+	},
+	themeButton: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		padding: 16,
+		width: '100%',
+	},
+	themeValue: {
+		fontSize: 15,
+	},
+	toggleRow: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		padding: 16,
+	},
+});
+
+export default memo(SettingsScreen);

--- a/src/store/selectors/settingsSelectors.ts
+++ b/src/store/selectors/settingsSelectors.ts
@@ -11,3 +11,7 @@ export const getTheme = (state: RootState): ETheme => {
 export const getShowOnboarding = (state: RootState): boolean => {
 	return state?.settings?.showOnboarding ?? true;
 };
+
+export const getAutoAuth = (state: RootState): boolean => {
+	return state?.settings?.autoAuth ?? false;
+};

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -4,6 +4,7 @@ import { ETheme, SettingsState } from '../../types/settings.ts';
 const initialState: SettingsState = {
 	theme: ETheme.system,
 	showOnboarding: true,
+	autoAuth: false,
 };
 
 const settingsSlice = createSlice({
@@ -16,12 +17,16 @@ const settingsSlice = createSlice({
 		updateShowOnboarding: (state, action: PayloadAction<{ showOnboarding: boolean }>) => {
 			state.showOnboarding = action.payload.showOnboarding;
 		},
+		updateAutoAuth: (state, action: PayloadAction<{ autoAuth: boolean }>) => {
+			state.autoAuth = action.payload.autoAuth;
+		},
 	},
 });
 
 export const {
 	updateTheme,
 	updateShowOnboarding,
+	updateAutoAuth,
 } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/src/theme/helpers.ts
+++ b/src/theme/helpers.ts
@@ -24,3 +24,13 @@ export const toggleTheme = ({
 			break;
 	}
 };
+
+export const setTheme = ({
+	dispatch,
+	theme,
+}: {
+	dispatch: Dispatch,
+	theme: ETheme
+}): void => {
+	dispatch(updateTheme({ theme }));
+};

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,6 +1,7 @@
 export interface SettingsState {
     theme: ETheme | undefined;
     showOnboarding: boolean;
+    autoAuth: boolean;
 }
 
 export enum ETheme {

--- a/src/utils/store-helpers.ts
+++ b/src/utils/store-helpers.ts
@@ -1,0 +1,19 @@
+import { store } from '../store';
+import { getAutoAuth } from '../store/selectors/settingsSelectors';
+import { RootState } from '../types';
+import { getPubky, isPubkySignedUp } from '../store/selectors/pubkySelectors.ts';
+import { Pubky } from '../types/pubky.ts';
+
+export const getStore = (): RootState => store.getState();
+
+export const getAutoAuthFromStore = (): boolean => {
+	return getAutoAuth(getStore()) ?? false;
+};
+
+export const getPubkyDataFromStore = (pubky: string): Pubky => {
+	return getPubky(getStore(), pubky);
+};
+
+export const getIsPubkySignedUpFromStore = (pubky: string): boolean => {
+	return isPubkySignedUp(getStore(), pubky);
+};


### PR DESCRIPTION
This PR:
- Implement Settings menu by double-tapping the logo from anywhere.
- Implement auto-auth feature for easier auth testing.
- Creates `store-helpers.ts`.
- Removes `pubkyData` from several methods to use `getPubkyDataFromStore` more directly instead.

![Simulator Screenshot - iPhone 15 Pro Max - 2025-01-03 at 13 03 48](https://github.com/user-attachments/assets/9ea606c5-eb5f-407c-b21f-9bb4ba648356)
