### PR TITLE
fix: fix auth modal toast position

### DIFF
--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -1,7 +1,15 @@
-import React, { memo, ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { memo, ReactElement, useCallback, useEffect, useState } from 'react';
 import { Alert, Dimensions, Image, StyleSheet } from 'react-native';
 import { PubkyAuthDetails } from '@synonymdev/react-native-pubky';
-import { ActionButton, ActionSheetContainer, AnimatedView, Folder, SessionText, Text, View } from '../theme/components';
+import {
+	ActionButton,
+	ActionSheetContainer,
+	AnimatedView,
+	Folder,
+	SessionText,
+	Text,
+	View,
+} from '../theme/components';
 import { SheetManager } from 'react-native-actions-sheet';
 import { performAuth } from '../utils/pubky';
 import { useDispatch, useSelector } from 'react-redux';
@@ -10,6 +18,8 @@ import PubkyCard from './PubkyCard.tsx';
 import { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { copyToClipboard } from '../utils/clipboard.ts';
 import { getNavigationAnimation } from '../store/selectors/settingsSelectors.ts';
+import Toast from 'react-native-toast-message';
+import { toastConfig } from '../theme/toastConfig.tsx';
 
 interface ConfirmAuthProps {
 	pubky: string;
@@ -24,6 +34,8 @@ interface Capability {
 }
 
 const { height } = Dimensions.get('window');
+const isSmallScreen = height < 700;
+const toastStyle = { top: isSmallScreen ? -120 : -140 };
 
 const Permission = memo(({ capability, isAuthorized }: { capability: Capability; isAuthorized: boolean }): ReactElement => {
 	const hasReadPermission = capability.permission.includes('r');
@@ -115,10 +127,6 @@ const ConfirmAuth = memo(({ payload }: { payload: ConfirmAuthProps }): ReactElem
 		SheetManager.hide('confirm-auth');
 	}, []);
 
-	const showImage = useMemo(() => {
-		return height >= 700;
-	}, []);
-
 	return (
 		<View style={styles.container}>
 			<ActionSheetContainer
@@ -149,7 +157,7 @@ const ConfirmAuth = memo(({ payload }: { payload: ConfirmAuthProps }): ReactElem
 						))}
 					</View>
 
-					{showImage && (
+					{!isSmallScreen && (
 						<View style={styles.imageContainer}>
 							<AnimatedView style={[styles.imageWrapper, checkStyle]}>
 								<Image
@@ -191,6 +199,7 @@ const ConfirmAuth = memo(({ payload }: { payload: ConfirmAuthProps }): ReactElem
 						</View>
 					</View>
 				</View>
+				<Toast config={toastConfig({ style: toastStyle })} />
 			</ActionSheetContainer>
 		</View>
 	);
@@ -371,7 +380,6 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'center',
 		marginBottom: 24,
-		zIndex: 3,
 	},
 	title: {
 		fontSize: 24,

--- a/src/components/PubkyDetail/PubkyDetail.tsx
+++ b/src/components/PubkyDetail/PubkyDetail.tsx
@@ -8,7 +8,6 @@ import { FlashList } from '@shopify/flash-list';
 import SessionItem from './SessionItem.tsx';
 import PubkyListHeader from './PubkyListHeader.tsx';
 import { PubkyData } from '../../navigation/types.ts';
-import { getKeychainValue } from '../../utils/keychain.ts';
 import { showBackupPrompt, showToast } from '../../utils/helpers.ts';
 import { Dispatch } from 'redux';
 import { Result } from '@synonymdev/result';
@@ -91,17 +90,7 @@ export const PubkyDetail = ({
 
 	const handleBackup = useCallback(async () => {
 		try {
-			const secretKeyResponse = await getKeychainValue({ key: pubky });
-			if (secretKeyResponse.isErr()) {
-				showToast({
-					type: 'error',
-					title: 'Error',
-					description: 'Could not retrieve secret key for backup',
-				});
-				return;
-			}
-			showBackupPrompt({ secretKey: secretKeyResponse.value, pubky });
-
+			showBackupPrompt({ pubky });
 		} catch (error) {
 			console.error('Backup process error:', error);
 			showToast({

--- a/src/theme/toastConfig.tsx
+++ b/src/theme/toastConfig.tsx
@@ -1,149 +1,100 @@
 import React, { useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, StyleProp, ViewStyle, TextStyle } from 'react-native';
 import styled from 'styled-components/native';
 import { BaseToast, ErrorToast, InfoToast, SuccessToast, ToastProps } from 'react-native-toast-message';
 import { useTheme } from 'styled-components/native';
 import { Theme } from './';
 
-const StyledBaseToast = styled(BaseToast)`
-    background-color: ${(props): string => props.theme.colors.cardBackground};
-    border-left-color: ${(props): string => props.theme.colors.border};
+type ToastConfigStyle = {
+    style?: StyleProp<ViewStyle>;
+};
+
+interface ThemedProps {
+    theme: Theme;
+}
+
+const StyledBaseToast = styled(BaseToast)<ThemedProps>`
+    background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
+    border-left-color: ${(props: ThemedProps): string => props.theme.colors.border};
 `;
 
-const StyledErrorToast = styled(ErrorToast)`
-    background-color: ${(props): string => props.theme.colors.cardBackground};
+const StyledErrorToast = styled(ErrorToast)<ThemedProps>`
+    background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
     border-left-color: #dc2626;
 `;
 
-const StyledSuccessToast = styled(SuccessToast)`
-    background-color: ${(props): string => props.theme.colors.cardBackground};
+const StyledSuccessToast = styled(SuccessToast)<ThemedProps>`
+    background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
     border-left-color: #16a34a;
 `;
 
-const StyledInfoToast = styled(InfoToast)`
-    background-color: ${(props): string => props.theme.colors.cardBackground};
+const StyledInfoToast = styled(InfoToast)<ThemedProps>`
+    background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
     border-left-color: #2563eb;
 `;
 
-// Create toast components that use the theme
-const ThemedSuccessToast = React.memo((props: any) => {
-	const theme = useTheme() as Theme;
-	const styles = useMemo(() => StyleSheet.create({
-		text1: {
-			fontSize: 15,
-			fontWeight: '600',
-			color: theme.colors.text,
-		},
-		text2: {
-			fontSize: 13,
-			fontWeight: '400',
-			color: theme.colors.sessionText,
-		},
-		contentContainer: {
-			paddingHorizontal: 15,
-		},
-	}), [theme.colors.text, theme.colors.sessionText]);
+interface ToastComponentProps extends ToastProps {
+    contentContainerStyle?: StyleProp<ViewStyle>;
+    text1Style?: StyleProp<TextStyle>;
+    text2Style?: StyleProp<TextStyle>;
+    style?: StyleProp<ViewStyle>;
+}
 
-	return (
-		<StyledSuccessToast
-			{...props}
-			contentContainerStyle={styles.contentContainer}
-			text1Style={styles.text1}
-			text2Style={styles.text2}
-		/>
-	);
-});
+const createThemedToast = (
+	ToastComponent: React.ComponentType<ToastComponentProps>
+): React.FC<ToastComponentProps> => {
+	return React.memo((props: ToastComponentProps): React.ReactElement => {
+		const theme = useTheme() as Theme;
+		const styles = useMemo(() => StyleSheet.create({
+			// eslint-disable-next-line react-native/no-unused-styles
+			text1: {
+				fontSize: 15,
+				fontWeight: '600',
+				color: theme.colors.text,
+			},
+			// eslint-disable-next-line react-native/no-unused-styles
+			text2: {
+				fontSize: 13,
+				fontWeight: '400',
+				color: theme.colors.sessionText,
+			},
+			// eslint-disable-next-line react-native/no-unused-styles
+			contentContainer: {
+				paddingHorizontal: 15,
+			},
+		}), [theme.colors.text, theme.colors.sessionText]);
 
-const ThemedErrorToast = React.memo((props: any) => {
-	const theme = useTheme() as Theme;
-	const styles = useMemo(() => StyleSheet.create({
-		text1: {
-			fontSize: 15,
-			fontWeight: '600',
-			color: theme.colors.text,
-		},
-		text2: {
-			fontSize: 13,
-			fontWeight: '400',
-			color: theme.colors.sessionText,
-		},
-		contentContainer: {
-			paddingHorizontal: 15,
-		},
-	}), [theme.colors.text, theme.colors.sessionText]);
-
-	return (
-		<StyledErrorToast
-			{...props}
-			contentContainerStyle={styles.contentContainer}
-			text1Style={styles.text1}
-			text2Style={styles.text2}
-		/>
-	);
-});
-
-const ThemedInfoToast = React.memo((props: any) => {
-	const theme = useTheme() as Theme;
-	const styles = useMemo(() => StyleSheet.create({
-		text1: {
-			fontSize: 15,
-			fontWeight: '600',
-			color: theme.colors.text,
-		},
-		text2: {
-			fontSize: 13,
-			fontWeight: '400',
-			color: theme.colors.sessionText,
-		},
-		contentContainer: {
-			paddingHorizontal: 15,
-		},
-	}), [theme.colors.text, theme.colors.sessionText]);
-
-	return (
-		<StyledInfoToast
-			{...props}
-			contentContainerStyle={styles.contentContainer}
-			text1Style={styles.text1}
-			text2Style={styles.text2}
-		/>
-	);
-});
-
-const ThemedBaseToast = React.memo((props: any) => {
-	const theme = useTheme() as Theme;
-	const styles = useMemo(() => StyleSheet.create({
-		// eslint-disable-next-line react-native/no-unused-styles
-		text1: {
-			fontSize: 15,
-			fontWeight: '600',
-			color: theme.colors.text,
-		},
-		// eslint-disable-next-line react-native/no-unused-styles
-		text2: {
-			fontSize: 13,
-			fontWeight: '400',
-			color: theme.colors.sessionText,
-		},
-		// eslint-disable-next-line react-native/no-unused-styles
-		contentContainer: {
-			paddingHorizontal: 15,
-		},
-	}), [theme.colors.text, theme.colors.sessionText]);
-
-	return (
-		<StyledBaseToast
-			{...props}
-			contentContainerStyle={styles.contentContainer}
-			text1Style={styles.text1}
-			text2Style={styles.text2}
-		/>
-	);
-});
-
-export const toastConfig = {
-	success: (props: ToastProps): React.ReactElement => <ThemedSuccessToast {...props} />,
-	error: (props: ToastProps): React.ReactElement => <ThemedErrorToast {...props} />,
-	info: (props: ToastProps): React.ReactElement => <ThemedInfoToast {...props} />,
-	any: (props: ToastProps): React.ReactElement => <ThemedBaseToast {...props} />,
+		return (
+			<ToastComponent
+				{...props}
+				contentContainerStyle={styles.contentContainer}
+				text1Style={styles.text1}
+				text2Style={styles.text2}
+			/>
+		);
+	});
 };
+
+const ThemedSuccessToast = createThemedToast(StyledSuccessToast);
+const ThemedErrorToast = createThemedToast(StyledErrorToast);
+const ThemedInfoToast = createThemedToast(StyledInfoToast);
+const ThemedBaseToast = createThemedToast(StyledBaseToast);
+
+type ToastConfigReturn = {
+	[key in 'success' | 'error' | 'info' | 'any']: (props: ToastProps) => React.ReactElement;
+};
+
+export const toastConfig = ({ style }: ToastConfigStyle = {}): ToastConfigReturn => ({
+	success: (props: ToastProps): React.ReactElement => (
+		<ThemedSuccessToast {...props} style={style} />
+	),
+	error: (props: ToastProps): React.ReactElement => (
+		<ThemedErrorToast {...props} style={style} />
+	),
+	info: (props: ToastProps): React.ReactElement => (
+		<ThemedInfoToast {...props} style={style} />
+	),
+	any: (props: ToastProps): React.ReactElement => (
+		<ThemedBaseToast {...props} style={style} />
+	),
+});


### PR DESCRIPTION
This PR:
- Adds toast to the top of the confirm auth modal view.
- Removes `secretKey` param from `showBackupPrompt` method.
- Moves `getKeychainValue` logic from `handleBackup` method.
- Adds loading indicator to Backup prompt.
- Closes #21