### PR TITLE
feat: restore pubkys

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, Suspense, useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { createNewPubky } from '../utils/pubky';
+import { createNewPubky, restorePubkys } from '../utils/pubky';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
 	View,
@@ -26,7 +26,10 @@ const OnboardingScreen = (): ReactElement => {
 	const dispatch = useDispatch();
 
 	const createPubky = useCallback(async () => {
-		await createNewPubky(dispatch);
+		await Promise.all([
+			restorePubkys(dispatch), // Check if there are already pubky's in the keychain and restore them
+			createNewPubky(dispatch),
+		]);
 		dispatch(updateShowOnboarding({ showOnboarding: false }));
 		navigation.replace('ConfirmPubky');
 	}, [dispatch, navigation]);


### PR DESCRIPTION
This PR:
- Attempts to restore old pubkys from uninstalled instances, if able, during the onboarding flow.
    - Not all devices will allow for it, but a check is made during onboarding for any old pubkys in the keychain and will restore them accordingly if found. If restored, they will appear in the user's pubky list, excluding any previously assigned name since that data is not retained in the keychain. 
- Closes #32