### PR TITLE
feat: monitor network status

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import './src/sheets/sheets';
 import { ThemeProvider } from 'styled-components/native';
 import { darkTheme, lightTheme } from './src/theme';
@@ -6,17 +6,54 @@ import RootNavigator from './src/navigation/RootNavigator.tsx';
 import { SheetProvider } from 'react-native-actions-sheet';
 import { useColorScheme } from 'react-native';
 import { ETheme } from './src/types/settings.ts';
-import { useSelector } from 'react-redux';
-import { getTheme } from './src/store/selectors/settingsSelectors.ts';
+import { useDispatch, useSelector } from 'react-redux';
+import { getIsOnline, getTheme } from './src/store/selectors/settingsSelectors.ts';
 import { SafeAreaView } from './src/theme/components.ts';
 import Toast from 'react-native-toast-message';
 import { toastConfig } from './src/theme/toastConfig.tsx';
+import NetInfo from '@react-native-community/netinfo';
+import { updateIsOnline } from './src/store/slices/settingsSlice.ts';
+import { checkNetworkConnection, showToast } from './src/utils/helpers.ts';
 
 const _toastConfig = toastConfig();
 
 function App(): React.JSX.Element {
 	const colorScheme = useColorScheme();
 	const currentTheme = useSelector(getTheme);
+	const isOnline = useSelector(getIsOnline);
+	const dispatch = useDispatch();
+
+	useEffect(() => {
+		checkNetworkConnection({
+			prevNetworkState: isOnline,
+			dispatch,
+			displayToast: true,
+		});
+
+		const unsubscribe = NetInfo.addEventListener(state => {
+			const isConnected = state?.isConnected ?? false;
+			if (isOnline !== isConnected) {
+				dispatch(updateIsOnline({ isOnline: isConnected }));
+				if (isConnected) {
+					showToast({
+						type: 'success',
+						title: "You're Back Online!",
+						description: 'You can now authorize with Pubky Ring',
+					});
+				} else {
+					showToast({
+						type: 'error',
+						title: 'Currently Offline',
+						description: 'You need to be online to authorize with Pubky Ring',
+						autoHide: false,
+					});
+				}
+			}
+		});
+
+		// Cleanup subscription on unmount
+		return (): void => unsubscribe();
+	}, [dispatch, isOnline]);
 
 	const theme = useMemo(() => {
 		switch (currentTheme) {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1275,6 +1275,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-netinfo (11.4.1):
+    - React-Core
   - react-native-pubky (0.9.4):
     - DoubleConversion
     - glog
@@ -2019,6 +2021,7 @@ DEPENDENCIES:
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - "react-native-pubky (from `../node_modules/@synonymdev/react-native-pubky`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-nativeconfig (from `../node_modules/react-native/ReactCommon`)
@@ -2148,6 +2151,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-document-picker"
   react-native-mmkv:
     :path: "../node_modules/react-native-mmkv"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
   react-native-pubky:
     :path: "../node_modules/@synonymdev/react-native-pubky"
   react-native-safe-area-context:
@@ -2274,6 +2279,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 19230cd0933df6f6dc1336c9a9edc382d62638ae
   react-native-document-picker: da64a39fd71a84a9d3f7f58c8b0623c393e9991c
   react-native-mmkv: 55e8a074ae9cb919609755d7271c16b242c2603f
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pubky: 54d13e11648545aeec27c6d1a58580ac12416312
   react-native-safe-area-context: 6b85173d2cee963d5232ac2fd260e8ebd63273dc
   React-nativeconfig: cd0fbb40987a9658c24dab5812c14e5522a64929

--- a/ios/pubkyring.xcodeproj/project.pbxproj
+++ b/ios/pubkyring.xcodeproj/project.pbxproj
@@ -405,7 +405,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -474,7 +477,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dr.pogodin/react-native-fs": "2.31.0",
     "@react-native-async-storage/async-storage": "^2.1.0",
     "@react-native-clipboard/clipboard": "^1.15.0",
+    "@react-native-community/netinfo": "^11.4.1",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
     "@reduxjs/toolkit": "^2.5.0",

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -2,7 +2,7 @@ import React, { memo, ReactElement, useCallback, useMemo, useState } from 'react
 import { Platform, StyleSheet } from 'react-native';
 import { Pubky } from '../types/pubky.ts';
 import { Dispatch } from 'redux';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
 	SessionText,
 	Box,
@@ -21,6 +21,7 @@ import {
 } from '../theme/components.ts';
 import { truncateStr } from '../utils/pubky.ts';
 import Jdenticon from './Jdenticon.tsx';
+import { getIsOnline } from '../store/selectors/settingsSelectors.ts';
 
 interface PubkyBoxProps {
 	pubky: string;
@@ -30,10 +31,12 @@ interface PubkyBoxProps {
 		pubky,
 		dispatch,
 		onComplete,
+		isOnline,
 	}: {
 		pubky: string;
 		dispatch: Dispatch;
 		onComplete?: () => void;
+		isOnline: boolean;
 	}) => Promise<string>;
 	onPress: (data: string) => void;
 	index?: number;
@@ -53,6 +56,7 @@ const PubkyBox = ({
 }: PubkyBoxProps): ReactElement => {
 	const [isQRLoading, setIsQRLoading] = useState(false);
 	const dispatch = useDispatch();
+	const isOnline = useSelector(getIsOnline);
 
 	const handleQRPress = useCallback(async () => {
 		setIsQRLoading(true);
@@ -60,11 +64,12 @@ const PubkyBox = ({
 			await onQRPress({
 				pubky,
 				dispatch,
+				isOnline,
 			});
 		} finally {
 			setIsQRLoading(false);
 		}
-	}, [dispatch, onQRPress, pubky]);
+	}, [dispatch, isOnline, onQRPress, pubky]);
 
 	const handleOnPress = useCallback(() => {
 		onPress(pubky);

--- a/src/components/PubkyDetail/PubkyDetail.tsx
+++ b/src/components/PubkyDetail/PubkyDetail.tsx
@@ -10,7 +10,6 @@ import PubkyListHeader from './PubkyListHeader.tsx';
 import { PubkyData } from '../../navigation/types.ts';
 import { showBackupPrompt, showToast } from '../../utils/helpers.ts';
 import { Dispatch } from 'redux';
-import { Result } from '@synonymdev/result';
 import { View } from '../../theme/components.ts';
 import { SheetManager } from 'react-native-actions-sheet';
 import { useNavigation } from '@react-navigation/native';
@@ -28,21 +27,11 @@ export interface PubkyDetailProps {
 		dispatch: Dispatch,
 		onComplete?: () => void,
 	}) => Promise<string>;
-    onCopyClipboard: ({
-    	pubky,
-    	pubkyData,
-    	dispatch,
-    }: {
-		pubky: string;
-		pubkyData: Pubky;
-		dispatch: Dispatch;
-	}) => Promise<Result<string>>
 }
 
 export const PubkyDetail = ({
 	pubkyData,
 	onQRPress,
-	onCopyClipboard,
 }: PubkyDetailProps): ReactElement => {
 	const { pubky, sessions } = pubkyData;
 	const publicKey = useMemo(() => pubky.startsWith('pk:') ? pubky.slice(3) : pubky, [pubky]);
@@ -53,10 +42,6 @@ export const PubkyDetail = ({
 	const handleQRPress = useCallback(() => {
 		return onQRPress({ pubky, pubkyData, dispatch });
 	}, [dispatch, onQRPress, pubky, pubkyData]);
-
-	const handleCopyClipboard = useCallback(async () => {
-		return onCopyClipboard({ pubky, pubkyData, dispatch });
-	}, [dispatch, onCopyClipboard, pubky, pubkyData]);
 
 	const onDelete = useCallback(async () => {
 		const deleteRes = await deletePubky(pubky, dispatch);
@@ -117,11 +102,10 @@ export const PubkyDetail = ({
 			pubkyData={pubkyData}
 			sessionsCount={sessionsLength}
 			onQRPress={handleQRPress}
-			onCopyClipboard={handleCopyClipboard}
 			onDelete={handleDelete}
 			onBackup={handleBackup}
 		/>
-	), [svg, pubky, pubkyData, sessionsLength, handleQRPress, handleCopyClipboard, handleDelete, handleBackup]);
+	), [svg, pubky, pubkyData, sessionsLength, handleQRPress, handleDelete, handleBackup]);
 
 	return (
 		<View style={styles.container}>

--- a/src/store/selectors/settingsSelectors.ts
+++ b/src/store/selectors/settingsSelectors.ts
@@ -19,3 +19,7 @@ export const getAutoAuth = (state: RootState): boolean => {
 export const getNavigationAnimation = (state: RootState): ENavigationAnimation => {
 	return state?.settings?.navigationAnimation ?? ENavigationAnimation.slideFromRight;
 };
+
+export const getIsOnline = (state: RootState): boolean => {
+	return state?.settings?.isOnline ?? true;
+};

--- a/src/store/slices/settingsSlice.ts
+++ b/src/store/slices/settingsSlice.ts
@@ -18,6 +18,9 @@ const settingsSlice = createSlice({
 		updateNavigationAnimation: (state, action: PayloadAction<{ navigationAnimation: ENavigationAnimation }>) => {
 			state.navigationAnimation = action.payload.navigationAnimation;
 		},
+		updateIsOnline: (state, action: PayloadAction<{ isOnline: boolean }>) => {
+			state.isOnline = action.payload.isOnline;
+		},
 	},
 });
 
@@ -26,6 +29,7 @@ export const {
 	updateShowOnboarding,
 	updateAutoAuth,
 	updateNavigationAnimation,
+	updateIsOnline,
 } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -3,6 +3,7 @@ export interface SettingsState {
     showOnboarding: boolean;
     autoAuth: boolean;
     navigationAnimation: ENavigationAnimation;
+    isOnline: boolean;
 }
 
 export enum ETheme {

--- a/src/utils/store-helpers.ts
+++ b/src/utils/store-helpers.ts
@@ -17,3 +17,7 @@ export const getPubkyDataFromStore = (pubky: string): Pubky => {
 export const getIsPubkySignedUpFromStore = (pubky: string): boolean => {
 	return isPubkySignedUp(getStore(), pubky);
 };
+
+export const getIsOnline = (): boolean => {
+	return getStore().settings.isOnline ?? true;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,6 +1602,11 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
+"@react-native-community/netinfo@^11.4.1":
+  version "11.4.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-11.4.1.tgz#a3c247aceab35f75dd0aa4bfa85d2be5a4508688"
+  integrity sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==
+
 "@react-native/assets-registry@0.77.0":
   version "0.77.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.77.0.tgz#15c0d65b386e61d669912dfdb2ddab225b10d5c3"


### PR DESCRIPTION
This PR:
- Monitors and notifies user with toast message if network status changes.
- Prevents user from opening the qr-scanner until they are back online. 
- Adds `@react-native-community/netinfo` as a dependency.
- Removed `onCopyClipboard` param and logic from `PubkyDetail.tsx`.
- Closes #40


![Simulator Screenshot - iPhone 16 - 2025-02-07 at 12 56 08](https://github.com/user-attachments/assets/95317422-cf90-4277-86e0-a15633df06b3)
