### PR TITLE
refactor: edit pubky styles

### DIFF
--- a/src/components/EditPubky.tsx
+++ b/src/components/EditPubky.tsx
@@ -324,9 +324,13 @@ const EditPubky = ({ payload }: {
 		);
 	}, [title]);
 
+	const footerTop = useMemo(() => {
+		return isSignupTokenEditable ? null : -100;
+	}, [isSignupTokenEditable]);
+
 	const renderListFooter = useCallback(() => {
 		return (
-			<View style={styles.footerContainer}>
+			<View style={[styles.footerContainer, { top: footerTop }]}>
 				{error ? (
 					<Text style={styles.errorText}>{error}</Text>
 				) : null}
@@ -345,7 +349,7 @@ const EditPubky = ({ payload }: {
 				</View>
 			</View>
 		);
-	}, [error, checkStyle, checkMarkGradient, checkMarkImage]);
+	}, [error, checkStyle, checkMarkGradient, checkMarkImage, footerTop]);
 
 	// eslint-disable-next-line react/no-unused-prop-types
 	const renderInputItem = useCallback(({ item }: { item: InputDataItem }) => {

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -56,7 +56,7 @@ export const ActionSheetContainer = styled(
 	defaultOverlayOpacity: 0.7,
 	statusBarTranslucent: true,
 	drawUnderStatusBar: false,
-	springOffset: props?.springOffset ?? 100,
+	springOffset: props?.springOffset ?? 80,
 	animated: true,
 	openAnimationConfig: props?.navigationAnimation === ENavigationAnimation.fade ? fadeAnimationConfig : openAnimationConfig,
 	closeAnimationConfig: props?.navigationAnimation === ENavigationAnimation.fade ? fadeAnimationConfig : undefined,


### PR DESCRIPTION
This PR:
- Updates footer style in the `EditPubky.tsx `component.
- Reduces `springOffset` default to 80 to make it easier to close modals, but without immediately closing scrollable modals.


![Simulator Screenshot - iPhone 8 - 2025-03-16 at 13 52 43](https://github.com/user-attachments/assets/7f1ae66b-d21f-43be-adcb-7b599d30aa69)
