### PR TITLE
refactor: optional file date

### DIFF
--- a/src/components/BackupPrompt.tsx
+++ b/src/components/BackupPrompt.tsx
@@ -134,9 +134,11 @@ const BackupPrompt = ({ payload }: {
 							<Text numberOfLines={1} ellipsizeMode="middle" style={styles.fileText}>
 								{fileName}
 							</Text>
-							<SessionText style={styles.dateText}>
-								{fileDate.toUpperCase()}
-							</SessionText>
+							{fileDate && (
+								<SessionText style={styles.dateText}>
+									{fileDate.toUpperCase()}
+								</SessionText>
+							)}
 						</View>
 					</View>
 				);

--- a/src/utils/rnfs.ts
+++ b/src/utils/rnfs.ts
@@ -113,12 +113,17 @@ export async function importFile(dispatch: Dispatch): Promise<Result<string>> {
 		const fileName = file.name;
 
 		const base64Content = await RNFS.readFile(filePath, 'base64');
-		const fileStats = await RNFS.stat(filePath);
-
+		let fileDate: Date | undefined;
+		try {
+			const fileStats = await RNFS.stat(filePath);
+			fileDate = fileStats.mtime;
+		} catch (statError) {
+			console.warn('Could not get file stats, using current date:', statError);
+		}
 
 		return showImportPrompt({
 			fileName: fileName ?? '',
-			fileDate: fileStats.mtime,
+			fileDate,
 			content: base64Content,
 			dispatch,
 		});
@@ -139,7 +144,7 @@ export const showImportPrompt = ({
 	dispatch,
 }: {
     fileName: string;
-    fileDate: Date;
+    fileDate?: Date;
     content: string;
     dispatch: Dispatch
 }): Promise<Result<string>> => {


### PR DESCRIPTION
This PR:
- Makes `fileDate` optional when importing `.pkarr` files in the event device permissions do not allow for it.