### PR TITLE
chore: upgrade react-native-pubky

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1305,7 +1305,7 @@ PODS:
     - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
-  - react-native-pubky (0.10.1):
+  - react-native-pubky (0.10.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2365,7 +2365,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 5cb1c6615796389f4f1b7fe2e4f103e38e4d6398
   react-native-mmkv: 55e8a074ae9cb919609755d7271c16b242c2603f
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pubky: 8cff3d2acfeff6b5401962e07b53db4dcb9e748e
+  react-native-pubky: 02ed91513b58a45c8f12f5f05e19b6db8cfd80f9
   react-native-safe-area-context: 286b3e7b5589795bb85ffc38faf4c0706c48a092
   react-native-skia: 3d4019882172140d9ea2f786fc3c20d818107e2e
   React-NativeModulesApple: fb48894de492e6f9a73e53d8f92a6a792e40666c

--- a/ios/pubkyring.xcodeproj/project.pbxproj
+++ b/ios/pubkyring.xcodeproj/project.pbxproj
@@ -405,7 +405,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -474,7 +477,10 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@reduxjs/toolkit": "^2.6.1",
     "@shopify/flash-list": "^1.7.6",
     "@shopify/react-native-skia": "^2.0.0-next.1",
-    "@synonymdev/react-native-pubky": "0.10.1",
+    "@synonymdev/react-native-pubky": "0.10.2",
     "@synonymdev/result": "^0.0.2",
     "buffer": "^6.0.3",
     "jdenticon": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,10 +1914,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@synonymdev/react-native-pubky@0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-pubky/-/react-native-pubky-0.10.1.tgz#7cd00ff765f5751114c6ed8c5f19bdfea2f56976"
-  integrity sha512-YGw+zMgps6qX0dQPL6uPan9vEKsd+xQDCGJvpe1ZtM6NhD8JZUS+SbUWPbNvPU89hRACnyMy3BjqBSrp3coX/w==
+"@synonymdev/react-native-pubky@0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-pubky/-/react-native-pubky-0.10.2.tgz#b5a8be0c91e1075491d752937844b9057de5ed06"
+  integrity sha512-YBeQan50HJ5edlwEaKQ2BEx0psxzxPRWH1SvavPTgazQIHaTav3bs6/+kqKHGfoTtaRcBExybuVzFdCvjMqlog==
   dependencies:
     "@synonymdev/result" "^0.0.2"
 


### PR DESCRIPTION
This PR:
- Upgrades `react-native-pubky` to `0.10.2`.
- Implements `getHomeserver` in `importPubky` method.
    - Imported pubky's with a homeserver no longer need to go through the "Setup" flow.