### PR TITLE
feat: add about screen

### DIFF
--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -16,6 +16,7 @@ import {
 } from '../store/selectors/settingsSelectors.ts';
 import SettingsScreen from '../screens/SettingsScreen.tsx';
 import TermsOfUse from '../screens/TermsOfUse.tsx';
+import About from '../screens/About.tsx';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -68,6 +69,14 @@ const RootNavigator = (): ReactElement => {
 						title: 'Pubky Ring',
 						gestureEnabled: false,
 						headerBackVisible: false,
+					}}
+				/>
+				<Stack.Screen
+					name="About"
+					component={About}
+					options={{
+						title: 'About',
+						gestureEnabled: true,
 					}}
 				/>
 				<Stack.Screen

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,6 +9,7 @@ export type RootStackParamList = {
   Onboarding: undefined;
   ConfirmPubky: undefined;
   Home: undefined;
+  About: undefined;
   Settings: undefined;
   PubkyDetail: {
     pubky: string;

--- a/src/screens/About.tsx
+++ b/src/screens/About.tsx
@@ -1,0 +1,232 @@
+import React, { memo, ReactElement, useMemo } from 'react';
+import { Image, Linking, StyleSheet, TouchableOpacity } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/types';
+import {
+	View,
+	Text,
+	NavButton,
+	ArrowLeft,
+	ArrowRight,
+	CardView,
+	ScrollView,
+	LinearGradient,
+} from '../theme/components.ts';
+import PubkyRingHeader from '../components/PubkyRingHeader';
+import { version } from '../../package.json';
+import PubkyRingLogo from '../images/pubky-ring.png';
+import { PUBKY_APP_URL, TERMS_OF_USE } from '../utils/constants.ts';
+import { shareData, showToast } from '../utils/helpers.ts';
+import { copyToClipboard } from '../utils/clipboard.ts';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'EditPubky'>;
+
+const onFooterPress = (): void => {
+	try {
+		Linking.openURL(PUBKY_APP_URL).then();
+	} catch {
+		showToast({
+			type: 'error',
+			title: 'Error',
+			description: 'Unable to open URL',
+		});
+	}
+};
+
+const onSharePress = (): void => {
+	shareData(PUBKY_APP_URL).then();
+};
+
+const onLegalPress = (): void => {
+	try {
+		Linking.openURL(TERMS_OF_USE).then();
+	} catch {}
+};
+
+const onCopyPress = (): void => {
+	copyToClipboard(version);
+	showToast({
+		type: 'info',
+		title: 'Copied version number to clipboard',
+		description: `Version: ${version}`,
+	});
+};
+
+const About = ({ navigation }: Props): ReactElement => {
+	const LeftButton = useMemo(() => (
+		<NavButton
+			style={styles.navButton}
+			onPressIn={navigation.goBack}
+			hitSlop={{ top: 20,
+				bottom: 20,
+				left: 20,
+				right: 20 }}
+		>
+			<ArrowLeft size={24} />
+		</NavButton>
+	), [navigation]);
+
+	const RightButton = useMemo(() => (
+		<NavButton style={styles.rightNavButton} />
+	),[]);
+
+	return (
+		<View style={styles.container}>
+			<PubkyRingHeader
+				leftButton={LeftButton}
+				rightButton={RightButton}
+			/>
+
+			<ScrollView style={styles.content}>
+				<Text style={styles.title}>Keychain for</Text>
+				<Text style={styles.lowerTitle}>the next web.</Text>
+				<Text style={styles.subtitle}>Pubky Ring enables you to securely authorize services and manage your pubkys, devices, and sessions.</Text>
+				<Text style={styles.subtitle}>Pubky Ring was crafted by Synonym Software Ltd. You are your keys.</Text>
+
+				<TouchableOpacity activeOpacity={0.8} onPress={onLegalPress} style={styles.row}>
+					<Text style={styles.rowTitle}>Legal</Text>
+					<ArrowRight />
+				</TouchableOpacity>
+
+				<CardView style={styles.divider} />
+
+				<TouchableOpacity activeOpacity={0.8} onPress={onSharePress} style={styles.row}>
+					<Text style={styles.rowTitle}>Share</Text>
+					<ArrowRight />
+				</TouchableOpacity>
+
+				<CardView style={styles.divider} />
+
+				<TouchableOpacity activeOpacity={0.8} onPress={onCopyPress} style={styles.row}>
+					<Text style={styles.rowTitle}>Version</Text>
+					<Text style={styles.rowTitle}>{version}</Text>
+				</TouchableOpacity>
+
+				<CardView style={styles.divider} />
+
+				<TouchableOpacity activeOpacity={0.8} onPress={onFooterPress}>
+					<LinearGradient style={styles.footer}>
+						<View style={styles.footerContent}>
+							<Text style={styles.footerText1}>Discover the next web</Text>
+							<Text style={styles.footerText2}>Your keys, your content, your rules.</Text>
+							<View style={styles.row}>
+								<Image
+									source={PubkyRingLogo}
+									style={styles.pubkyLogo}
+								/>
+								<ArrowRight />
+							</View>
+						</View>
+					</LinearGradient>
+				</TouchableOpacity>
+
+			</ScrollView>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		padding: 16,
+	},
+	title: {
+		fontSize: 48,
+		fontWeight: 700,
+		lineHeight: 48,
+		textAlign: 'left',
+	},
+	lowerTitle: {
+		fontSize: 48,
+		fontWeight: 700,
+		lineHeight: 48,
+		textAlign: 'left',
+		marginBottom: 16,
+	},
+	subtitle: {
+		fontSize: 17,
+		fontWeight: 400,
+		lineHeight: 22,
+		letterSpacing: 0.4,
+		marginBottom: 16,
+		opacity: 0.8,
+	},
+	row: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		width: '100%',
+		height: 60,
+		backgroundColor: 'transparent',
+	},
+	rowTitle: {
+		fontSize: 17,
+		fontWeight: 400,
+		lineHeight: 22,
+		letterSpacing: 0.4,
+	},
+	divider: {
+		height: 1,
+		width: '100%',
+		marginVertical: 5,
+	},
+	footer: {
+		marginTop: 40,
+		borderRadius: 16,
+		alignSelf: 'center',
+		shadowColor: '#000',
+		shadowOffset: {
+			width: 0,
+			height: 1,
+		},
+		shadowOpacity: 0.1,
+		shadowRadius: 2,
+		elevation: 2,
+		marginBottom: 20,
+		marginHorizontal: 24,
+		width: '100%',
+	},
+	footerContent: {
+		margin: 25,
+		backgroundColor: 'transparent',
+	},
+	footerText1: {
+		fontSize: 26,
+		fontWeight: 300,
+		lineHeight: 26,
+		letterSpacing: 0,
+	},
+	footerText2: {
+		fontSize: 15,
+		fontWeight: 600,
+		lineHeight: 20,
+		letterSpacing: 0.4,
+		marginBottom: 16,
+	},
+	pubkyLogo: {
+		height: 48,
+		resizeMode: 'contain',
+		backgroundColor: 'transparent',
+	},
+
+	rightNavButton: {
+		width: 40,
+		height: 40,
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'center',
+		backgroundColor: 'transparent',
+	},
+	navButton: {
+		zIndex: 1,
+		height: 40,
+		width: 40,
+		alignSelf: 'center',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+});
+
+export default memo(About);

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -19,7 +19,7 @@ import { Pubky, TPubkys } from '../types/pubky';
 import { createNewPubky } from '../utils/pubky';
 import { showEditPubkyPrompt, showQRScanner, showToast } from '../utils/helpers';
 import { importFile } from '../utils/rnfs';
-import { View, Plus, TouchableOpacity } from '../theme/components';
+import { View, Plus, TouchableOpacity, CircleAlert, NavButton } from '../theme/components';
 import PubkyRingHeader from '../components/PubkyRingHeader.tsx';
 import Button from '../components/Button';
 import { reorderPubkys } from '../store/slices/pubkysSlice.ts';
@@ -35,6 +35,7 @@ import {
 import PubkyRingLogo from '../images/pubky-ring.png';
 // @ts-ignore
 import DeviceMobileLogo from '../images/device-mobile.png';
+import { PUBKY_APP_URL } from '../utils/constants.ts';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
@@ -201,8 +202,7 @@ const HomeScreen = (): ReactElement => {
 
 	const onFooterPress = useCallback( () => {
 		try {
-			const url = 'https://beta.pubky.app';
-			Linking.openURL(url).then();
+			Linking.openURL(PUBKY_APP_URL).then();
 		} catch {
 			showToast({
 				type: 'error',
@@ -212,6 +212,24 @@ const HomeScreen = (): ReactElement => {
 		}
 	}, []);
 
+	const LeftButton = useMemo(() => (
+		<NavButton
+			style={styles.navButton}
+			onPressIn={() => navigation.navigate('About')}
+			hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
+		>
+			<CircleAlert size={24} />
+		</NavButton>
+	), [navigation]);
+
+	const RightButton = useMemo(() => (
+		<NavButton style={styles.rightNavButton} />
+	), []);
+
+	const HeaderComponent = useMemo(() => (
+		<PubkyRingHeader leftButton={LeftButton} rightButton={RightButton} />
+	), [LeftButton, RightButton]);
+
 	return (
 		<View style={styles.container}>
 			{_hasPubkys ? (
@@ -220,7 +238,7 @@ const HomeScreen = (): ReactElement => {
 					onDragEnd={handleDragEnd}
 					keyExtractor={(item, index) => `${item.key}${index}`}
 					renderItem={renderItem}
-					ListHeaderComponent={PubkyRingHeader}
+					ListHeaderComponent={HeaderComponent}
 					ListFooterComponent={ListFooter}
 					contentContainerStyle={styles.listContent}
 					showsVerticalScrollIndicator={false}
@@ -345,6 +363,23 @@ const styles = StyleSheet.create({
 		resizeMode: 'contain',
 		backgroundColor: 'black',
 		marginRight: -28,
+	},
+	navButton: {
+		zIndex: 1,
+		height: 40,
+		width: 40,
+		alignSelf: 'center',
+		alignItems: 'center',
+		justifyContent: 'center',
+		right: -5,
+	},
+	rightNavButton: {
+		width: 40,
+		height: 40,
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'center',
+		backgroundColor: 'transparent',
 	},
 });
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -223,8 +223,8 @@ const styles = StyleSheet.create({
 		padding: 16,
 	},
 	rightNavButton: {
-		width: 32,
-		height: 32,
+		width: 40,
+		height: 40,
 		justifyContent: 'center',
 		alignItems: 'center',
 		alignSelf: 'center',

--- a/src/screens/TermsOfUse.tsx
+++ b/src/screens/TermsOfUse.tsx
@@ -8,7 +8,7 @@ import {
 } from '../theme/components.ts';
 import LinearGradient from 'react-native-linear-gradient';
 import PubkyRingHeader from '../components/PubkyRingHeader.tsx';
-import { ONBOARDING_KEY_RADIAL_GRADIENT } from '../utils/constants.ts';
+import { ONBOARDING_KEY_RADIAL_GRADIENT, TERMS_OF_USE } from '../utils/constants.ts';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types.ts';
@@ -18,13 +18,6 @@ import { hasPubkys } from '../store/selectors/pubkySelectors.ts';
 import { getShowOnboarding } from '../store/selectors/settingsSelectors.ts';
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList, 'TermsOfUse'>;
-
-const onPrivacyFormPress = (): void => {
-	try {
-		Linking.openURL('https://docs.google.com/document/d/1nVT03MDSY635xDyVP41leIroR1iwmTDr/edit#heading=h.rqj4bs5k3v1l').then(() => setPrivacyChecked(!privacyChecked));
-	} catch {}
-};
-
 
 const TermsOfUse = (): React.ReactElement => {
 	const navigation = useNavigation<NavigationProp>();
@@ -43,6 +36,13 @@ const TermsOfUse = (): React.ReactElement => {
 			navigation.replace(showOnboarding ? 'Onboarding' : (_hasPubkys ? 'Home' : 'Onboarding'));
 		}
 	}, [_hasPubkys, canContinue, dispatch, navigation, showOnboarding]);
+
+	const onPrivacyFormPress = (): void => {
+		try {
+			Linking.openURL(TERMS_OF_USE).then(() => setPrivacyChecked(!privacyChecked));
+		} catch {}
+	};
+
 
 	return (
 		<View style={styles.container}>

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -5,6 +5,7 @@ import {
 	Share as _Share,
 	ArrowLeft as _ArrowLeft,
 	ChevronLeft as _ChevronLeft,
+	CircleAlert as _CircleAlert,
 	Eye as _Eye,
 	EyeOff as _EyeOff,
 	Plus as _Plus,
@@ -203,6 +204,10 @@ export const Save = styled(_Save)`
 `;
 
 export const ArrowLeft = styled(_ArrowLeft)`
+  color: ${(props): string => props.theme.colors.text};
+`;
+
+export const CircleAlert = styled(_CircleAlert)`
   color: ${(props): string => props.theme.colors.text};
 `;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,5 @@ export const AUTHORIZE_KEY_GRADIENT = ['#101F30', '#131C25', '#14181D', '#171818
 
 //export const DEFAULT_HOMESERVER = 'ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy';
 export const DEFAULT_HOMESERVER = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
+export const PUBKY_APP_URL = 'https://beta.pubky.app';
+export const TERMS_OF_USE = 'https://docs.google.com/document/d/1kE1GSJ8AUqa3qhPUsJnoMF9ZWFxOlZsKUtAPaVr5V7k';


### PR DESCRIPTION
This PR:
- Adds `About` component.
- Adds `PUBKY_APP_URL` & `TERMS_OF_USE` to `constants.ts`.
- Updates constant uses accordingly.
- Updates nav button styles.
- Adds `CircleAlert` to `components.ts`.
- Moves `onPrivacyFormPress` back in render.

![Simulator Screenshot - iPhone 16 Pro - 2025-03-27 at 23 11 46](https://github.com/user-attachments/assets/2018b369-a9ec-4094-a55e-66cb62c304ca)
