### PR TITLE
chore: remove beta link

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,5 +7,5 @@ export const AUTHORIZE_KEY_GRADIENT = ['#101F30', '#131C25', '#14181D', '#171818
 
 //export const DEFAULT_HOMESERVER = 'ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy';
 export const DEFAULT_HOMESERVER = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
-export const PUBKY_APP_URL = 'https://beta.pubky.app';
+export const PUBKY_APP_URL = 'https://pubky.app';
 export const TERMS_OF_USE = 'https://synonym.to/pubky-ring-privacy-policy';


### PR DESCRIPTION
This PR:
- Replaces `PUBKY_APP_URL` beta link in `constants.ts`.