### PR TITLE
fix: Update auth flow for a single signed up pubky

### DIFF
--- a/src/store/selectors/pubkySelectors.ts
+++ b/src/store/selectors/pubkySelectors.ts
@@ -39,7 +39,7 @@ export const getAllPubkys = (state: RootState): { [key: string]: Pubky } => {
 	return state.pubky.pubkys;
 };
 
-export const hasPubkys = (state: RootState): boolean => {
+export const getHasPubkys = (state: RootState): boolean => {
 	return Object.keys(state.pubky.pubkys).length > 0;
 };
 


### PR DESCRIPTION
This PR:
- Updates the auth flow logic for when only a single signed up pubky is detected.
- The user is now forwarded immediately to the auth confirmation screen.
- Renames `hasPubkys` selector to `getHasPubkys` in `pubkySelectors.ts`.