### PR TITLE
fix: improve EditPubky UX and fix Android keyboard issues

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,7 +5,7 @@ export const ONBOARDING_PUBKY_RADIAL_GRADIENT = ['#2A333E', '#282B2F'];
 
 export const AUTHORIZE_KEY_GRADIENT = ['#101F30', '#131C25', '#14181D', '#171818', '#191919', '#121212'];
 
-//export const DEFAULT_HOMESERVER = 'ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy';
 export const DEFAULT_HOMESERVER = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
+export const STAGING_HOMESERVER = 'ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy';
 export const PUBKY_APP_URL = 'https://pubky.app';
 export const TERMS_OF_USE = 'https://synonym.to/pubky-ring-privacy-policy';


### PR DESCRIPTION
This PR:
- Reorders input fields: invite code now appears before homeserver
- Adds automatic invite code formatting for default and staging homeserver (XXXX-XXXX-XXXX)
- Fixes Android modal flickering when keyboard appears/dismisses
- Adds fade animations to error state transitions
- Improves logic around submit behavior between text inputs
- Clears error states when fields revert to original values
- Implements `KeyboardAvoidingView`
- Updates button state logic
- Adds `STAGING_HOMESERVER` to `constants.ts`