### PR TITLE
feat: add import success

### DIFF
--- a/src/components/ImportSuccessSheet.tsx
+++ b/src/components/ImportSuccessSheet.tsx
@@ -1,0 +1,109 @@
+import React, {
+	memo,
+	ReactElement,
+	useCallback,
+	useMemo,
+} from 'react';
+import {
+	Platform,
+	StyleSheet,
+} from 'react-native';
+import {
+	View,
+	ActionSheetContainer,
+} from '../theme/components.ts';
+import { SheetManager } from 'react-native-actions-sheet';
+import { useSelector } from 'react-redux';
+import { getNavigationAnimation } from '../store/selectors/settingsSelectors.ts';
+import absoluteFillObject = StyleSheet.absoluteFillObject;
+import { Pubky } from "../types/pubky.ts";
+import PubkyReview from "./PubkySetup/PubkyReview.tsx";
+import { getPubky, getPubkyCount } from "../store/selectors/pubkySelectors.ts";
+import { RootState } from "../store";
+const ACTION_SHEET_HEIGHT = Platform.OS === 'ios' ? '95%' : '100%';
+
+const ImportSuccessSheet = ({ payload }: {
+    payload: {
+        modalTitle?: string;
+        description?: string;
+		isNewPubky?: boolean;
+        pubky: string;
+        data?: Pubky;
+        onContinue?: () => void;
+    };
+}): ReactElement => {
+	const navigationAnimation = useSelector(getNavigationAnimation);
+	const pubkyCount = useSelector(getPubkyCount);
+	const pubky = useMemo(() => payload?.pubky ?? '', [payload?.pubky]);
+	const isNewPubky = useMemo(() => payload?.isNewPubky ?? false, [payload?.isNewPubky]);
+	const onContinue = useCallback(async (): Promise<void> => {
+		try {
+			await SheetManager.hide('import-success');
+			if (!isNewPubky) {
+				// If re-imported, just return to avoid going back to the setup flow
+				return;
+			}
+			setTimeout(() => {
+				payload.onContinue?.();
+			}, 200);
+		} catch {}
+	}, [isNewPubky, payload]);
+
+	const pubkyData = useSelector((state: RootState) => getPubky(state, pubky));
+
+	const modalTitle = useMemo(() => {
+		if (!isNewPubky) {
+			return 'Pubky Re-Imported';
+		}
+		return payload?.modalTitle ?? 'Pubky Imported';
+	}, [isNewPubky, payload?.modalTitle]);
+	const description = useMemo(() => {
+		if (!isNewPubky) {
+			return 'You successfully re-imported your Pubky.';
+		}
+		return payload?.description ?? 'You successfully imported your Pubky.';
+	}, [isNewPubky, payload?.description]);
+
+	const data = useMemo(() => {
+		return { ...pubkyData, pubky, name: pubkyData.name || `pubky #${pubkyCount}` };
+	}, [pubky, pubkyCount, pubkyData]);
+
+	return (
+		<View style={styles.container}>
+			<ActionSheetContainer
+				id="import-success"
+				navigationAnimation={navigationAnimation}
+				keyboardHandlerEnabled={Platform.OS === 'ios'}
+				//isModal={Platform.OS === 'ios'}
+				CustomHeaderComponent={<></>}
+				height={ACTION_SHEET_HEIGHT}
+			>
+				<View style={styles.fullSize}>
+					<PubkyReview
+						modalTitle={modalTitle}
+						description={description}
+						pubky={pubky}
+						pubkyData={data}
+						onContinue={onContinue}
+					/>
+				</View>
+			</ActionSheetContainer>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		...absoluteFillObject,
+		backgroundColor: 'transparent',
+		height: '100%',
+		width: '100%',
+		zIndex: 100,
+	},
+	fullSize: {
+		height: '100%',
+		width: '100%',
+	},
+});
+
+export default memo(ImportSuccessSheet);

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -268,10 +268,12 @@ const styles = StyleSheet.create({
 		opacity: 0.7,
 	},
 	backupContainer: {
-		padding: 4,
+		paddingHorizontal: 8,
+		paddingVertical: 2,
 		backgroundColor: textStyles.backupTextBGColor,
-		borderRadius: 80,
-		marginLeft: 5
+		borderRadius: 16,
+		marginLeft: 5,
+		alignSelf: 'center',
 	}
 });
 

--- a/src/components/PubkySetup/NewPubkySetup.tsx
+++ b/src/components/PubkySetup/NewPubkySetup.tsx
@@ -59,8 +59,8 @@ const Content = ({
 			return (
 				<View style={styles.fullSize}>
 					<PubkyReview
-						title={title}
-						subTitle={subTitle}
+						modalTitle={title}
+						description={subTitle}
 						pubky={pubky}
 						pubkyData={pubkyData}
 						onContinue={() => setCurrentScreen(ECurrentScreen.homeserver)}

--- a/src/components/PubkySetup/PubkyReview.tsx
+++ b/src/components/PubkySetup/PubkyReview.tsx
@@ -14,16 +14,18 @@ import PubkyProfile from '../PubkyProfile.tsx';
 import { PubkyData } from "../../navigation/types.ts";
 
 interface PubkyReviewProps {
-	title: string;
-	subTitle: string;
+	modalTitle: string;
+	headerText?: string;
+	description: string;
 	pubky: string;
 	pubkyData: PubkyData;
 	onContinue: () => void;
 }
 
 const PubkyReview = ({
-	title,
-	subTitle,
+	modalTitle,
+	headerText,
+	description,
 	pubky,
 	pubkyData,
 	onContinue
@@ -36,11 +38,13 @@ const PubkyReview = ({
 		>
 			<ModalIndicator />
 			<View style={styles.titleContainer}>
-				<Text style={styles.title}>{title}</Text>
+				<Text style={styles.title}>{modalTitle}</Text>
 			</View>
-			<Text style={styles.headerText}>Your pubky.</Text>
+			{headerText && (
+				<Text style={styles.headerText}>{headerText}</Text>
+			)}
 			<SessionText style={styles.message}>
-				{subTitle}
+				{description}
 			</SessionText>
 			<ForegroundView style={styles.profileCard}>
 				<PubkyProfile

--- a/src/sheets/index.ts
+++ b/src/sheets/index.ts
@@ -11,6 +11,7 @@ const SelectBackupPreference = lazy(() => import('../components/SelectBackupPref
 const EditPubky = lazy(() => import('../components/EditPubky.tsx'));
 const SelectPubky = lazy(() => import('../components/SelectPubky.tsx'));
 const RecoveryPhrasePrompt = lazy(() => import('../components/RecoveryPhrasePrompt.tsx'));
+const ImportSuccessSheet = lazy(() => import('../components/ImportSuccessSheet.tsx'));
 
 registerSheet('camera', QRScanner as any);
 registerSheet('backup-prompt', BackupPrompt as any);
@@ -22,6 +23,7 @@ registerSheet('select-backup-preference', SelectBackupPreference as any);
 registerSheet('edit-pubky', EditPubky as any);
 registerSheet('add-pubky', AddPubky as any);
 registerSheet('select-pubky', SelectPubky as any);
+registerSheet('import-success', ImportSuccessSheet as any);
 
 declare module 'react-native-actions-sheet' {
 	interface Sheets {
@@ -41,6 +43,7 @@ declare module 'react-native-actions-sheet' {
 		'edit-pubky': SheetDefinition;
 		'add-pubky': SheetDefinition;
 		'select-pubky': SheetDefinition;
+		'import-success': SheetDefinition;
 	}
 }
 

--- a/src/store/selectors/pubkySelectors.ts
+++ b/src/store/selectors/pubkySelectors.ts
@@ -63,6 +63,13 @@ export const getHasPubkys = (state: RootState): boolean => {
 };
 
 /**
+ * Get all pubky keys (pubky identifiers)
+ */
+export const getPubkyKeys = (state: RootState): string[] => {
+	return Object.keys(state.pubky.pubkys);
+};
+
+/**
  * Combined selector for HomeScreen to reduce re-renders
  */
 export const getHomeScreenData = createSelector(

--- a/src/store/shapes/pubky.ts
+++ b/src/store/shapes/pubky.ts
@@ -1,4 +1,4 @@
-import { EBackupPreference, Pubky, PubkyState } from '../../types/pubky.ts';
+import { EBackupPreference, Pubky, PubkyState, TProfile } from '../../types/pubky.ts';
 
 export const initialState: PubkyState = {
 	pubkys: {},
@@ -14,4 +14,11 @@ export const defaultPubkyState: Pubky = {
 	sessions: [],
 	backupPreference: EBackupPreference.encryptedFile,
 	isBackedUp: false
+};
+
+export const defaultProfile: TProfile = {
+	name: "",
+	bio: "",
+	image: "",
+	links: [],
 };

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -89,9 +89,9 @@ export const textStyles = {
 		letterSpacing: 0.4,
 	} as TextStyle,
 	backupText: {
-		color: '#377CE8',
+		color: '#0085FF',
 	},
-	backupTextBGColor: '#1C2B3D',
+	backupTextBGColor: 'rgba(0, 133, 255, 0.16)',
 	caption: {
 		fontSize: 13,
 		fontWeight: '500' as const,

--- a/src/types/pubky.ts
+++ b/src/types/pubky.ts
@@ -36,3 +36,13 @@ export enum EBackupPreference {
 	encryptedFile = 'encryptedFile',
 	unknown = 'unknown',
 }
+
+export type TProfile = {
+	name: string;
+	bio: string;
+	image: string;
+	links: {
+		title: string;
+		url: string;
+	}[];
+};

--- a/src/utils/rnfs.ts
+++ b/src/utils/rnfs.ts
@@ -147,8 +147,20 @@ export async function importFile(dispatch: Dispatch): Promise<Result<string>> {
 		});
 
 	} catch (error) {
-		console.error('Import error:', error);
-		return err(`Failed to import pubky: ${JSON.stringify(error)}`);
+		const errMsg = `Failed to import file: ${JSON.stringify(error)}`;
+		try {
+			if (error &&
+				typeof error === 'object' &&
+				'code' in error &&
+				error?.code === 'OPERATION_CANCELED'
+			) {
+				return err(error.code);
+			}
+
+		} catch (e) {
+			return err(errMsg);
+		}
+		return err(errMsg);
 	}
 }
 

--- a/src/utils/sheetHelpers.ts
+++ b/src/utils/sheetHelpers.ts
@@ -57,6 +57,34 @@ export const showEditPubkySheet = ({
 	});
 };
 
+export const showImportSuccessSheet = ({
+	modalTitle = 'Pubky Imported',
+	description,
+	isNewPubky = true,
+	pubky,
+	data = { ...defaultPubkyState },
+	onContinue = (): void => {},
+}: {
+	modalTitle?: string;
+	description?: string;
+	isNewPubky?: boolean;
+	pubky: string;
+	data?: Pubky;
+	onContinue?: () => void;
+}): void => {
+	SheetManager.show('import-success', {
+		payload: {
+			modalTitle,
+			description,
+			isNewPubky,
+			pubky,
+			data,
+			onContinue
+		},
+		onClose: () => SheetManager.hide('import-success'),
+	});
+};
+
 export const showBackupPrompt = async ({
 	pubky,
 	backupPreference,


### PR DESCRIPTION
This PR:
- Create `ImportSuccessSheet.tsx`
- Update logic around re-imported pubkys
- Remove toast messages for successfully imported pubkys
- Add pubky profile name fetching for successful imports with the default Synonym homeserver
- Add `getPubkyKeys` selector
- Add `defaultProfile` shape
- Add `TProfile` type
- Update backup text colors
- Add `getProfileInfo` function
- Update import logic
- Improve error response in importFile function
- Add `showImportSuccessSheet` function to `sheetHelpers.ts`
- Update `PubkyReview` props in `PubkyReview.tsx`