### PR TITLE
chore: upgrade react-native-camera-kit

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2717,7 +2717,7 @@ PODS:
     - React-perflogger (= 0.83.1)
     - React-utils (= 0.83.1)
     - SocketRocket
-  - ReactNativeCameraKit (17.0.0):
+  - ReactNativeCameraKit (17.0.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3669,7 +3669,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: bfb12ead469222b022a2024f32aba47ce50de512
   ReactCodegen: 894c9c13d45d134966e464ad5453a6d81f197910
   ReactCommon: 05ad684db7d88e194272ae26baddf6300e30b8b7
-  ReactNativeCameraKit: fc81eacb725db08226b9fcb67546c1535b6ed5ed
+  ReactNativeCameraKit: 9e87676354a7fe881db8ef227dc666a44a6ad426
   ReactNativeFs: b94c72969131e2dc113fedd9f1f3dafd117bac7a
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCClipboard: 962296f7af77f6c039b683e21c2e2255af9c05df

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-i18next": "^16.3.5",
     "react-native": "0.83.1",
     "react-native-actions-sheet": "^10.1.1",
-    "react-native-camera-kit": "^17.0.0",
+    "react-native-camera-kit": "^17.0.1",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "^2.30.0",
     "react-native-keychain": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8695,10 +8695,10 @@ react-native-actions-sheet@^10.1.1:
   resolved "https://registry.yarnpkg.com/react-native-actions-sheet/-/react-native-actions-sheet-10.1.1.tgz#396869d6dec0d518a0677a0f0fa3fb59eb38a5c4"
   integrity sha512-hNdLgfWGiBdJ7J8MNycGRT6cfz46q4+mIrbYq9Jfh5aXYhxToWzEekixRVLE7mG2KCuEv8XYto7N7b410kpKJQ==
 
-react-native-camera-kit@^17.0.0:
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-camera-kit/-/react-native-camera-kit-17.0.0.tgz#57adf24debedfd2289969bafdaec3f4af4b481d4"
-  integrity sha512-lGQV+ijVtj3a2HONRXN5sCBw5jwfj6C3MFmuV1a/vEAFVvd8sASs2kb64WIYDTgWmOTwUEjdbLK1Gju09CmNiQ==
+react-native-camera-kit@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-camera-kit/-/react-native-camera-kit-17.0.1.tgz#97ac40c7395e3768be5d8a2ba8d77772e798b9be"
+  integrity sha512-DcXfyiNl1yXytDgCxbpny1BbhXnUUpQdzI144v9KhkgSLJo/m7ELC6uuMimQAH6h1ccRW29fQ5KY8BGboHEmww==
 
 react-native-draggable-flatlist@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
This PR:
- Upgrades  react-native-camera-kit to `17.0.1`