### PR TITLE
fix signup docstring param

### DIFF
--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -2,7 +2,7 @@
  * Signup Action Handler
  *
  * Handles signup deeplinks that create a new pubky and authorize with a service.
- * Format: pubkyauth://signup?hs={homeserver}&ic={invite_code}&relay={relay}&secret={secret}&caps={capabilities}
+ * Format: pubkyauth://signup?hs={homeserver}&st={signup_token}&relay={relay}&secret={secret}&caps={capabilities}
  */
 
 import { Result, ok, err } from '@synonymdev/result';


### PR DESCRIPTION
Nit: small typo on docstrings.

It would make sense to me to also rename all instances of `inviteCode` (when used as a param of pubkyauth urls) into `signupToken`, so it aligns with `pubky-sdk` naming. E.g.
https://github.com/pubky/pubky-ring/blob/a1b5f9963fa07817a85eb5ccc5dbeab06b5e0389/src/utils/inputParser.ts#L166