### PR TITLE
fix: add strokewidth to lucide icons

### DIFF
--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -10,6 +10,8 @@ import {
 	Text,
 	View,
 	SkiaGradient,
+	Globe,
+	CircleCheck,
 } from '../theme/components';
 import { SheetManager } from 'react-native-actions-sheet';
 import { performAuth } from '../utils/pubky';
@@ -26,7 +28,6 @@ import { getNavigationAnimation } from '../store/selectors/settingsSelectors.ts'
 import Toast from 'react-native-toast-message';
 import { toastConfig } from '../theme/toastConfig.tsx';
 import ModalIndicator from './ModalIndicator.tsx';
-import { Globe } from 'lucide-react-native';
 import {
 	ACTION_SHEET_HEIGHT,
 	SMALL_SCREEN_ACTION_SHEET_HEIGHT,
@@ -34,7 +35,6 @@ import {
 import { buttonStyles } from '../theme/utils';
 import { RootState } from '../store';
 import { getPubkyName } from '../store/selectors/pubkySelectors.ts';
-import { CircleCheck } from 'lucide-react-native';
 import ProgressBar from './ProgressBar.tsx';
 import SystemNavigationBar from 'react-native-system-navigation-bar';
 import { useTranslation } from 'react-i18next';

--- a/src/components/PubkySetup/InviteCode.tsx
+++ b/src/components/PubkySetup/InviteCode.tsx
@@ -23,11 +23,12 @@ import {
 	AuthorizeButton,
 	TouchableOpacity,
 	AnimatedView,
+	Gift,
+	Check,
 } from '../../theme/components.ts';
 import { SheetManager } from 'react-native-actions-sheet';
 import ModalIndicator from '../ModalIndicator.tsx';
 import DashedBorder from '../DashedBorder.tsx';
-import { Gift, Check } from 'lucide-react-native';
 import { formatSignupToken, isSmallScreen, isValidSignupTokenFormat } from '../../utils/helpers.ts';
 import {
 	useAnimatedStyle,

--- a/src/components/PubkySetup/RequestInviteCode.tsx
+++ b/src/components/PubkySetup/RequestInviteCode.tsx
@@ -15,10 +15,12 @@ import {
 	SessionText,
 	RadialGradient,
 	TouchableOpacity,
+	ArrowLeft,
+	Mail,
+	Send,
 } from '../../theme/components.ts';
 import { SheetManager } from 'react-native-actions-sheet';
 import ModalIndicator from '../ModalIndicator.tsx';
-import { ArrowLeft, Mail, Send } from 'lucide-react-native';
 import XLogo from '../XLogo.tsx';
 import { INVITE_CODE_GRADIENT } from '../../utils/constants.ts';
 

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -22,6 +22,11 @@ import {
 	KeyRound as _KeyRound,
 	Folder as _Folder,
 	Settings as _Settings,
+	Globe as _Globe,
+	CircleCheck as _CircleCheck,
+	Gift as _Gift,
+	Mail as _Mail,
+	Send as _Send,
 } from 'lucide-react-native';
 import ActionSheet from 'react-native-actions-sheet';
 import Animated from 'react-native-reanimated';
@@ -33,6 +38,9 @@ import {
 import { LinearGradient as _LinearGradient } from 'react-native-linear-gradient';
 import { SafeAreaView as _SafeAreaView } from 'react-native-safe-area-context';
 import { SafeAreaProvider as _SafeAreaProvider } from 'react-native-safe-area-context';
+
+// Default stroke width for Lucide icons to improve sharpness on high-DPI displays
+const ICON_STROKE_WIDTH = 2.5;
 
 interface ActionSheetContainerProps {
   backgroundColor?: string;
@@ -197,88 +205,108 @@ export const ActivityIndicator = styled.ActivityIndicator<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const QrCode = styled(_QrCode)<{ theme: Theme }>`
+export const QrCode = styled(_QrCode).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Scan = styled(_Scan)<{ theme: Theme }>`
+export const Scan = styled(_Scan).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const ArrowRight = styled(_ChevronRight)<{ theme: Theme }>`
+export const ArrowRight = styled(_ChevronRight).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Plus = styled(_Plus)<{ theme: Theme }>`
+export const Plus = styled(_Plus).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.text};
 `;
 
-export const Clipboard = styled(_Clipboard)<{ theme: Theme }>`
+export const Clipboard = styled(_Clipboard).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Share = styled(_Share)<{ theme: Theme }>`
+export const Share = styled(_Share).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Trash2 = styled(_Trash2)<{ theme: Theme }>`
+export const Trash2 = styled(_Trash2).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Save = styled(_Save)<{ theme: Theme }>`
+export const Save = styled(_Save).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const ArrowLeft = styled(_ArrowLeft)<{ theme: Theme }>`
+export const ArrowLeft = styled(_ArrowLeft).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.text};
 `;
 
-export const CircleAlert = styled(_CircleAlert)<{ theme: Theme }>`
+export const CircleAlert = styled(_CircleAlert).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.text};
 `;
 
-export const Info = styled(_Info)<{ theme: Theme }>`
+export const Info = styled(_Info).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.text};
 `;
 
-export const ChevronLeft = styled(_ChevronLeft)<{ theme: Theme }>`
+export const ChevronLeft = styled(_ChevronLeft).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const ChevronRight = styled(_ChevronRight)<{ theme: Theme }>`
+export const ChevronRight = styled(_ChevronRight).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Check = styled(_Check)<{ theme: Theme }>`
+export const Check = styled(_Check).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	  color: ${(props): string => props.theme.colors.text};
 `;
 
-export const Pencil = styled(_Pencil)<{ theme: Theme }>`
+export const Pencil = styled(_Pencil).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 		  color: ${(props): string => props.theme.colors.text};
 `;
 
-export const Edit2 = styled(_Edit2)<{ theme: Theme }>`
+export const Edit2 = styled(_Edit2).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 		  color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Eye = styled(_Eye)<{ theme: Theme }>`
+export const Eye = styled(_Eye).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const EyeOff = styled(_EyeOff)<{ theme: Theme }>`
+export const EyeOff = styled(_EyeOff).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const KeyRound = styled(_KeyRound)<{ theme: Theme }>`
+export const KeyRound = styled(_KeyRound).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
   color: ${(props): string => props.theme.colors.sessionText};
 `;
 
-export const Folder = styled(_Folder)<{ theme: Theme }>`
+export const Folder = styled(_Folder).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	  color: ${(props): string => props.theme.colors.text};
 `;
 
-export const Settings = styled(_Settings)<{ theme: Theme }>`
+export const Settings = styled(_Settings).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
 	  color: ${(props): string => props.theme.colors.text};
+`;
+
+export const Globe = styled(_Globe).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
+  color: ${(props): string => props.theme.colors.sessionText};
+`;
+
+export const CircleCheck = styled(_CircleCheck).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
+  color: ${(props): string => props.theme.colors.text};
+`;
+
+export const Gift = styled(_Gift).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
+  color: ${(props): string => props.theme.colors.sessionText};
+`;
+
+export const Mail = styled(_Mail).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
+  color: ${(props): string => props.theme.colors.sessionText};
+`;
+
+export const Send = styled(_Send).attrs({ strokeWidth: ICON_STROKE_WIDTH })<{ theme: Theme }>`
+  color: ${(props): string => props.theme.colors.sessionText};
 `;
 
 interface LinearGradientProps {


### PR DESCRIPTION
This PR:
- Adds `strokewidth` of `2.5` to all lucid icons.