### PR TITLE
fix: prevent duplicate keys when rescanning onboarding QR

### DIFF
--- a/src/store/selectors/pubkySelectors.ts
+++ b/src/store/selectors/pubkySelectors.ts
@@ -108,6 +108,22 @@ export const hasPubky = (state: RootState, pubky: string): boolean => {
 	return !!state.pubky.pubkys[pubky];
 };
 
+/**
+ * Find the key of the pubky associated with a given signup token.
+ * Returns null when the token is empty or no match exists.
+ */
+export const getPubkyKeyBySignupToken = (
+	state: RootState,
+	signupToken: string,
+): string | null => {
+	if (!signupToken) return null;
+	const pubkys = state.pubky.pubkys;
+	for (const key in pubkys) {
+		if (pubkys[key]?.signupToken === signupToken) return key;
+	}
+	return null;
+};
+
 export const isProcessing = (state: RootState, key: string): boolean => {
 	return key in state.pubky.processing;
 };

--- a/src/store/slices/pubkysSlice.ts
+++ b/src/store/slices/pubkysSlice.ts
@@ -11,14 +11,15 @@ const pubkysSlice = createSlice({
 	name: 'pubky',
 	initialState,
 	reducers: {
-		addPubky: (state, action: PayloadAction<{ pubky: string, backupPreference?: EBackupPreference, isBackedUp?: boolean }>) => {
+		addPubky: (state, action: PayloadAction<{ pubky: string, backupPreference?: EBackupPreference, isBackedUp?: boolean, signupToken?: string }>) => {
 			state.pubkys = state?.pubkys || {};
-			const { pubky, backupPreference, isBackedUp = false } = action.payload;
+			const { pubky, backupPreference, isBackedUp = false, signupToken = '' } = action.payload;
 			if (!state.pubkys[pubky]) {
 				state.pubkys[pubky] = {
 					...defaultPubkyState,
 					backupPreference: backupPreference ?? defaultPubkyState.backupPreference,
 					isBackedUp,
+					signupToken,
 				};
 			}
 		},

--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -22,7 +22,11 @@ import { SHEET_ANIMATION_DELAY } from '../constants.ts';
 import i18n from '../../i18n';
 import { SheetManager } from 'react-native-actions-sheet';
 import { Dispatch } from 'redux';
-import { getSignedUpPubkysFromStore } from '../store-helpers';
+import {
+	getPubkyDataFromStore,
+	getPubkyKeyBySignupTokenFromStore,
+	getSignedUpPubkysFromStore,
+} from '../store-helpers';
 import { showPubkySelectionSheet } from '../../hooks/inputHandlerUtils';
 
 type SignupActionData = {
@@ -54,9 +58,20 @@ export const handleSignupAction = async (
 ): Promise<Result<string>> => {
 	const { dispatch } = context;
 	const { params } = data;
-	const { xCallback } = params;
+	const { xCallback, homeserver, inviteCode, relay, secret, caps } = params;
 
 	let pubky = '';
+	let isReusedPubky = false;
+	let secretKey: string | undefined;
+	let mnemonic: string | undefined;
+
+	const capsString = caps.join(',');
+	const authUrl = `pubkyauth:///?relay=${encodeURIComponent(relay)}&secret=${encodeURIComponent(secret)}&caps=${encodeURIComponent(capsString)}`;
+	const authData = {
+		action: InputAction.Auth,
+		params: { relay, secret, caps, xCallback },
+		rawUrl: authUrl,
+	} as const;
 
 	// Small delay to ensure any previous sheet (e.g., camera) has fully closed
 	await new Promise(resolve => setTimeout(resolve, SHEET_ANIMATION_DELAY));
@@ -69,37 +84,59 @@ export const handleSignupAction = async (
 		},
 	});
 
-	// Step 1: Generate a new keypair
-	const genKeyRes = await generateMnemonicPhraseAndKeypair();
-	if (genKeyRes.isErr()) {
-		showErrorState(i18n.t('signup.failedToGenerateKeypair'), dispatch);
-		await openXError(xCallback, 'SIGNUP_FAILED', i18n.t('signup.failedToGenerateKeypair'));
-		return err(i18n.t('signup.failedToGenerateKeypair'));
+	// If a pubky already exists for this signup token (e.g. user is rescanning the
+	// same onboarding QR after a prior failure), reuse it instead of creating a new key.
+	const existingPubkyKey = getPubkyKeyBySignupTokenFromStore(inviteCode);
+	if (existingPubkyKey) {
+		const existingPubky = getPubkyDataFromStore(existingPubkyKey);
+		pubky = existingPubkyKey;
+		isReusedPubky = true;
+
+		if (existingPubky?.signedUp) {
+			// Already signed up to homeserver — skip signup and forward to auth.
+			await SheetManager.hide('loading');
+			await new Promise(resolve => setTimeout(resolve, SHEET_ANIMATION_DELAY));
+			await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
+			return ok(pubky);
+		}
 	}
 
-	const { mnemonic, secret_key: secretKey, public_key: generatedPubky } = genKeyRes.value;
-	pubky = generatedPubky;
+	// Step 1: Generate a new keypair only if we don't have an existing match
+	if (!isReusedPubky) {
+		const genKeyRes = await generateMnemonicPhraseAndKeypair();
+		if (genKeyRes.isErr()) {
+			showErrorState(i18n.t('signup.failedToGenerateKeypair'), dispatch);
+			await openXError(xCallback, 'SIGNUP_FAILED', i18n.t('signup.failedToGenerateKeypair'));
+			return err(i18n.t('signup.failedToGenerateKeypair'));
+		}
+
+		const { mnemonic: genMnemonic, secret_key: genSecretKey, public_key: generatedPubky } = genKeyRes.value;
+		mnemonic = genMnemonic;
+		secretKey = genSecretKey;
+		pubky = generatedPubky;
+	}
 
 	try {
-		const { homeserver, inviteCode, relay, secret, caps } = params;
-
 		// Set processing state
 		dispatch(addProcessing({ pubky }));
 
-		// Step 2: Save the pubky to keychain and Redux
-		const saveRes = await savePubky({
-			mnemonic,
-			secretKey,
-			pubky,
-			dispatch,
-			backupPreference: EBackupPreference.unknown,
-			isBackedUp: false,
-		});
+		// Step 2: Save the pubky to keychain and Redux (new keys only)
+		if (!isReusedPubky) {
+			const saveRes = await savePubky({
+				mnemonic,
+				secretKey: secretKey as string,
+				pubky,
+				dispatch,
+				backupPreference: EBackupPreference.unknown,
+				isBackedUp: false,
+				signupToken: inviteCode,
+			});
 
-		if (saveRes.isErr()) {
-			showErrorState(i18n.t('pubkyErrors.failedToSavePubky'), dispatch);
-			await openXError(xCallback, 'SIGNUP_FAILED', i18n.t('pubkyErrors.failedToSavePubky'));
-			return err(i18n.t('pubkyErrors.failedToSavePubky'));
+			if (saveRes.isErr()) {
+				showErrorState(i18n.t('pubkyErrors.failedToSavePubky'), dispatch);
+				await openXError(xCallback, 'SIGNUP_FAILED', i18n.t('pubkyErrors.failedToSavePubky'));
+				return err(i18n.t('pubkyErrors.failedToSavePubky'));
+			}
 		}
 
 		// Step 3: Sign up to the specified homeserver with invite code
@@ -110,9 +147,6 @@ export const handleSignupAction = async (
 			signupToken: inviteCode,
 			dispatch,
 		});
-
-		const capsString = caps.join(',');
-		const authUrl = `pubkyauth:///?relay=${encodeURIComponent(relay)}&secret=${encodeURIComponent(secret)}&caps=${encodeURIComponent(capsString)}`;
 
 
 		if (signupRes.isErr()) {
@@ -128,8 +162,6 @@ export const handleSignupAction = async (
 				await new Promise(resolve => {
 					setTimeout(resolve, SHEET_ANIMATION_DELAY);
 				});
-
-				const authData = { action: InputAction.Auth, params: { relay, secret, caps, xCallback }, rawUrl: authUrl } as const;
 
 				if (signedUpKeys.length === 1) {
 					// Single pubky: auto-forward to auth
@@ -184,11 +216,7 @@ export const handleSignupAction = async (
 		await new Promise(resolve => {setTimeout(resolve, SHEET_ANIMATION_DELAY);});
 
 		await handleAuthAction(
-			{
-				action: InputAction.Auth,
-				params: { relay, secret, caps, xCallback },
-				rawUrl: authUrl,
-			},
+			authData,
 			{
 				...context,
 				pubky,

--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -76,14 +76,6 @@ export const handleSignupAction = async (
 	// Small delay to ensure any previous sheet (e.g., camera) has fully closed
 	await new Promise(resolve => setTimeout(resolve, SHEET_ANIMATION_DELAY));
 
-	// Show loading modal FIRST (don't await - it resolves when sheet closes)
-	// This ensures errors are visible via the modal's error state
-	SheetManager.show('loading', {
-		payload: {
-			modalTitle: i18n.t('loading.modalTitle'),
-		},
-	});
-
 	// If a pubky already exists for this signup token (e.g. user is rescanning the
 	// same onboarding QR after a prior failure), reuse it instead of creating a new key.
 	const existingPubkyKey = getPubkyKeyBySignupTokenFromStore(inviteCode);
@@ -93,13 +85,19 @@ export const handleSignupAction = async (
 		isReusedPubky = true;
 
 		if (existingPubky?.signedUp) {
-			// Already signed up to homeserver — skip signup and forward to auth.
-			await SheetManager.hide('loading');
-			await new Promise(resolve => setTimeout(resolve, SHEET_ANIMATION_DELAY));
+			// Already signed up to homeserver — skip the loading modal and signup and forward to auth.
 			await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
 			return ok(pubky);
 		}
 	}
+
+	// Show loading modal (don't await - it resolves when sheet closes)
+	// This ensures errors are visible via the modal's error state
+	SheetManager.show('loading', {
+		payload: {
+			modalTitle: i18n.t('loading.modalTitle'),
+		},
+	});
 
 	// Step 1: Generate a new keypair only if we don't have an existing match
 	if (!isReusedPubky) {

--- a/src/utils/pubky.ts
+++ b/src/utils/pubky.ts
@@ -331,6 +331,7 @@ export const savePubky = async ({
 	mnemonic = '',
 	backupPreference = EBackupPreference.unknown,
 	isBackedUp = false,
+	signupToken = '',
 }: {
 	secretKey: string,
 	pubky: string,
@@ -338,6 +339,7 @@ export const savePubky = async ({
 	mnemonic?: string,
 	backupPreference?: EBackupPreference;
 	isBackedUp?: boolean;
+	signupToken?: string;
 }): Promise<Result<string>> => {
 	try {
 		// Ensure the mnemonic phrase generates the expected secretKey
@@ -356,7 +358,7 @@ export const savePubky = async ({
 			// If no mnemonic is provided we have to default to the encrypted file.
 			backupPreference = EBackupPreference.encryptedFile;
 		}
-		dispatch(addPubky({ pubky, backupPreference, isBackedUp }));
+		dispatch(addPubky({ pubky, backupPreference, isBackedUp, signupToken }));
 		const keychainData: IKeychainData = {
 			secretKey,
 			mnemonic,

--- a/src/utils/store-helpers.ts
+++ b/src/utils/store-helpers.ts
@@ -1,7 +1,7 @@
 import { store } from '../store';
 import { getAutoAuth } from '../store/selectors/settingsSelectors';
 import { RootState } from '../types';
-import { getPubky, isPubkySignedUp, getSignedUpPubkys } from '../store/selectors/pubkySelectors.ts';
+import { getPubky, isPubkySignedUp, getSignedUpPubkys, getPubkyKeyBySignupToken } from '../store/selectors/pubkySelectors.ts';
 import { EBackupPreference, Pubky } from '../types/pubky.ts';
 
 export const getStore = (): RootState => store.getState();
@@ -28,4 +28,8 @@ export const getBackupPreference = (pubky: string): EBackupPreference => {
 
 export const getSignedUpPubkysFromStore = (): { [key: string]: Pubky } => {
 	return getSignedUpPubkys(getStore());
+};
+
+export const getPubkyKeyBySignupTokenFromStore = (signupToken: string): string | null => {
+	return getPubkyKeyBySignupToken(getStore(), signupToken);
 };


### PR DESCRIPTION
This PR:

- Persists `signupToken` on `addPubky`/`savePubky` so it's saved the moment a key is created.
- Creates new `getPubkyKeyBySignupToken` selector & `getPubkyKeyBySignupTokenFromStore` helper to find an existing pubky by its signup token.
- `handleSignupAction` now checks for an existing pubky with the scanned token before generating a new keypair. If one exists and is already signed up, skip signup and go straight to auth; if it exists but isn't signed up yet, reuse the key and retry `signUpToHomeserver`.
- Fixes #274: Rescanning the onboarding QR after a failed authorization no longer produces useless extra keys.