### PR TITLE
build(android): upgrade camera kit to fix new architecture builds

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:usesCleartextTraffic="true" />
+</manifest>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-i18next": "^16.3.5",
     "react-native": "0.85.2",
     "react-native-actions-sheet": "^10.1.2",
-    "react-native-camera-kit": "^17.0.1",
+    "react-native-camera-kit": "18.0.0",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "^2.31.2",
     "react-native-keychain": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9044,10 +9044,10 @@ react-native-actions-sheet@^10.1.2:
   dependencies:
     react-native-worklets "^0.7.1"
 
-react-native-camera-kit@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-camera-kit/-/react-native-camera-kit-17.0.1.tgz#97ac40c7395e3768be5d8a2ba8d77772e798b9be"
-  integrity sha512-DcXfyiNl1yXytDgCxbpny1BbhXnUUpQdzI144v9KhkgSLJo/m7ELC6uuMimQAH6h1ccRW29fQ5KY8BGboHEmww==
+react-native-camera-kit@18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-camera-kit/-/react-native-camera-kit-18.0.0.tgz#77d419d4c67d382ee8b1e31d47c2b73d51f01efa"
+  integrity sha512-FZG9kB8GDGcxTUB2cGhBn2wexIgzevv+PE7zfpLz6i/9kltDCLO/fomLhFvSaQVL2Bnu8AtxbBiI8Im0O8AqDA==
 
 react-native-draggable-flatlist@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
### Description

- Upgrades `react-native-camera-kit` from `17.0.1` to `18.0.0` to pick up the Android new architecture/codegen fix needed for RN `0.85`.
- Adds a debug-only Android manifest that allows cleartext traffic so local debug builds can connect to the Metro development server.

### QA Notes

- Verified the Android build succeeds locally after upgrading `react-native-camera-kit` and the app can connect to the dev server.