### PR TITLE
fix: offline signup/auth

### DIFF
--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -209,8 +209,8 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 	const titleText = isAuthorized
 		? t('auth.authorizationSuccessful')
 		: xCallback?.xSource
-		? t('auth.authorizeForApp', { appName: xCallback.xSource })
-		: t('auth.authorize');
+			? t('auth.authorizeForApp', { appName: xCallback.xSource })
+			: t('auth.authorize');
 
 	return (
 		<ActionSheetContainer

--- a/src/hooks/inputHandlerUtils.ts
+++ b/src/hooks/inputHandlerUtils.ts
@@ -148,7 +148,7 @@ export const handleNoPubkysAvailable = (
 									SheetManager.hide('add-pubky');
 								},
 							});
-					  }
+						}
 					: undefined,
 		});
 	}

--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -7,10 +7,10 @@
 
 import { Result, ok, err } from '@synonymdev/result';
 import { generateMnemonicPhraseAndKeypair } from '@synonymdev/react-native-pubky';
-import { InputAction, SignupParams, XCallbackParams } from '../inputParser';
+import { InputAction, SignupParams } from '../inputParser';
 import { ActionContext } from '../inputRouter';
 import { savePubky, signUpToHomeserver } from '../pubky';
-import { showToast } from '../helpers';
+import { checkNetworkConnection, showToast } from '../helpers';
 import { getErrorMessage } from '../errorHandler';
 import { openXError } from '../xCallback';
 import { addProcessing, removeProcessing } from '../../store/slices/pubkysSlice';
@@ -61,6 +61,22 @@ export const handleSignupAction = async (
 	const { dispatch } = context;
 	const { params } = data;
 	const { xCallback, homeserver, inviteCode, relay, secret, caps } = params;
+
+	const isOnline = await checkNetworkConnection({
+		dispatch,
+		displayToastIfOnline: false,
+		displayToastIfOffline: false,
+	});
+	if (!isOnline) {
+		const offlineMessage = i18n.t('network.offlineDescription');
+		showToast({
+			type: 'error',
+			title: i18n.t('network.currentlyOffline'),
+			description: offlineMessage,
+		});
+		await openXError(xCallback, 'OFFLINE', offlineMessage);
+		return err(offlineMessage);
+	}
 
 	let pubky = '';
 	let isReusedPubky = false;
@@ -163,30 +179,7 @@ export const handleSignupAction = async (
 				await new Promise(resolve => {
 					setTimeout(resolve, SHEET_ANIMATION_DELAY);
 				});
-
-				if (signedUpKeys.length === 1) {
-					// Single pubky: auto-forward to auth
-					return await handleAuthAction(authData, { ...context, pubky: signedUpKeys[0], isDeeplink: false });
-				} else {
-					// Multiple pubkys: show selector, then forward to auth
-					const selectedPubky = await showPubkySelectionSheet(
-						{
-							action: InputAction.Auth,
-							data: authData,
-							source: 'scan',
-							rawInput: authUrl,
-						},
-						'scan',
-						dispatch,
-					);
-
-					if (!selectedPubky) {
-						// User dismissed without selecting - return error
-						return err('User cancelled pubky selection');
-					}
-
-					return await handleAuthAction(authData, { ...context, pubky: selectedPubky, isDeeplink: false });
-				}
+				return await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
 			}
 
 			// No existing pubkys - show error as before

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -76,7 +76,11 @@ export const getErrorMessage = (error: unknown, fallback = i18n.t('errors.unknow
 };
 
 export class AppError extends Error {
-	constructor(message: string, public code: string, public recoverable = true) {
+	constructor(
+		message: string,
+		public code: string,
+		public recoverable = true,
+	) {
 		super(message);
 		this.name = 'AppError';
 	}

--- a/src/utils/inputRouter.ts
+++ b/src/utils/inputRouter.ts
@@ -83,7 +83,7 @@ export const routeInput = async (
 						action: InputAction.Import,
 						pubky: result.value,
 						message: i18n.t('router.importSuccessful'),
-				  })
+					})
 				: err(getErrorMessage(result.error, i18n.t('errors.importFailed')));
 		}
 
@@ -95,7 +95,7 @@ export const routeInput = async (
 						action: InputAction.Migrate,
 						pubky: result.value,
 						message: i18n.t('router.migrateSuccessful'),
-				  })
+					})
 				: err(getErrorMessage(result.error, i18n.t('errors.migrateFailed')));
 		}
 
@@ -107,7 +107,7 @@ export const routeInput = async (
 						action: InputAction.Signup,
 						pubky: result.value,
 						message: i18n.t('router.signupSuccessful'),
-				  })
+					})
 				: err(getErrorMessage(result.error, i18n.t('errors.signupFailed')));
 		}
 
@@ -119,7 +119,7 @@ export const routeInput = async (
 						action: InputAction.Invite,
 						pubky: result.value,
 						message: i18n.t('router.inviteProcessed'),
-				  })
+					})
 				: err(getErrorMessage(result.error, i18n.t('errors.inviteProcessingFailed')));
 		}
 
@@ -131,7 +131,7 @@ export const routeInput = async (
 						action: InputAction.Session,
 						pubky: result.value,
 						message: i18n.t('router.sessionReturned'),
-				  })
+					})
 				: err(getErrorMessage(result.error, i18n.t('errors.sessionRequestFailed')));
 		}
 

--- a/src/utils/pubky.ts
+++ b/src/utils/pubky.ts
@@ -26,7 +26,7 @@ import {
 } from '../store/slices/pubkysSlice';
 import { Result, err, ok } from '@synonymdev/result';
 import { defaultProfile, defaultPubkyState } from '../store/shapes/pubky';
-import { showToast } from './helpers.ts';
+import { checkNetworkConnection, showToast } from './helpers.ts';
 import { getErrorMessage } from './errorHandler.ts';
 import { auth } from '@synonymdev/react-native-pubky';
 import { getPubkyDataFromStore } from './store-helpers.ts';
@@ -630,6 +630,13 @@ export const performAuth = async ({
 	dispatch: Dispatch;
 }): Promise<Result<string>> => {
 	try {
+		const isOnline = await checkNetworkConnection({
+			displayToastIfOnline: false,
+			displayToastIfOffline: false,
+		});
+		if (!isOnline) {
+			return err(i18n.t('network.offlineDescription'));
+		}
 		const authPromise = (async (): Promise<Result<string>> => {
 			if (!pubky) {
 				return err(i18n.t('pubkyErrors.pubkyRequiredForAuth'));


### PR DESCRIPTION
This PR:
- Adds isOnline checks to the sign-up/in and auth flows to notify/prevent the user from entering an auth flow while the device is offline.
- Removes the `signedUpKeys.length` check in `handleSignupAction`
  - Should address [this](https://github.com/pubky/pubky-ring/issues/274#issuecomment-4431374589) comment. We know the pubky so don't need to present the user with a list of pubkys to select from to auth with.
- Ran `npm run format`