### PR TITLE
fix(ui): correct text clipping, layering, and card layout issues

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -77,6 +77,8 @@ const styles = StyleSheet.create({
 	text: {
 		...textStyles.bodySSB,
 		alignSelf: 'center',
+		flexShrink: 1,
+		textAlign: 'center',
 	},
 });
 

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -214,6 +214,7 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 	},
 	contentContainer: {
+		flex: 1,
 		justifyContent: 'center',
 		alignItems: 'flex-start',
 		backgroundColor: 'transparent',

--- a/src/components/PubkySetup/NewHomeserverSetup.tsx
+++ b/src/components/PubkySetup/NewHomeserverSetup.tsx
@@ -158,6 +158,7 @@ const styles = StyleSheet.create({
 		justifyContent: 'center',
 		marginBottom: 24,
 		backgroundColor: 'transparent',
+		zIndex: 1,
 	},
 	title: {
 		...textStyles.bodyMB,
@@ -170,12 +171,14 @@ const styles = StyleSheet.create({
 		marginBottom: 16,
 		color: '#FFFFFF',
 		backgroundColor: 'transparent',
+		zIndex: 1,
 	},
 	message: {
 		...textStyles.bodyM,
 		marginBottom: 30,
 		color: '#FFFFFF',
 		backgroundColor: 'transparent',
+		zIndex: 1,
 	},
 	optionsContainer: {
 		marginBottom: 20,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -116,15 +116,6 @@ const HomeScreen = (): ReactElement => {
 		[pubkysProcessing],
 	);
 
-	const getItemLayout = useCallback(
-		(data: any, index: number) => ({
-			length: 172,
-			offset: 172 * index,
-			index,
-		}),
-		[],
-	);
-
 	const keyExtractor = useCallback(
 		(item: { key: string; value: Pubky }, index: number) => `${item.key}-${index}`,
 		[],
@@ -157,7 +148,6 @@ const HomeScreen = (): ReactElement => {
 				contentContainerStyle={styles.listContent}
 				showsVerticalScrollIndicator={false}
 				showsHorizontalScrollIndicator={false}
-				getItemLayout={getItemLayout}
 			/>
 			{/* Fixed footer */}
 			<View style={styles.fixedFooterContainer}>

--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -82,7 +82,7 @@ export const textStyles = {
 	display: {
 		fontSize: 48,
 		fontWeight: '700' as const,
-		lineHeight: 48,
+		lineHeight: 58,
 		letterSpacing: 0,
 		fontFamily,
 		color: 'white',
@@ -90,7 +90,7 @@ export const textStyles = {
 	heading: {
 		fontSize: 26,
 		fontWeight: '300' as const,
-		lineHeight: 26,
+		lineHeight: 32,
 		letterSpacing: 0,
 		fontFamily,
 	} as TextStyle,


### PR DESCRIPTION
This PR:
- Lifts Homeserver sheet text above the device image (zIndex)
- Increases display/heading lineHeight so descenders aren't clipped
- Gives shared Button label a bounded width to fix "Add pubky" truncation
- Adds `flex:1` to PubkyBox content column so long names don't expand the card
- Removes stale `getItemLayout` so the pubky list self-measures row heights