### PR TITLE
fix(ui): polish pubky card variants

### DIFF
--- a/src/components/AnimatedQR.tsx
+++ b/src/components/AnimatedQR.tsx
@@ -1,10 +1,9 @@
 import React, { memo, ReactElement, useCallback, useEffect, useRef, useState } from 'react';
-import { Pressable, StyleSheet } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
-import { View, AnimatedView } from '../theme/components.ts';
 import { useTranslation } from 'react-i18next';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { BodySMText } from '../theme/typography';
-import { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import { ChevronLeft, ChevronRight } from '../icons/index.ts';
 
 const pubkyRingLogo = require('../images/pubky-ring.png');
@@ -144,22 +143,22 @@ const AnimatedQR = ({
 					</View>
 					{showControls && (
 						<>
-							<AnimatedView
+							<Animated.View
 								style={[styles.chevron, styles.chevronLeft, controlsAnimatedStyle]}
 								pointerEvents={isPaused ? 'auto' : 'none'}
 							>
 								<Pressable onPress={handlePrevious} hitSlop={CHEVRON_HIT_SLOP}>
 									<ChevronLeft size={32} />
 								</Pressable>
-							</AnimatedView>
-							<AnimatedView
+							</Animated.View>
+							<Animated.View
 								style={[styles.chevron, styles.chevronRight, controlsAnimatedStyle]}
 								pointerEvents={isPaused ? 'auto' : 'none'}
 							>
 								<Pressable onPress={handleNext} hitSlop={CHEVRON_HIT_SLOP}>
 									<ChevronRight size={32} />
 								</Pressable>
-							</AnimatedView>
+							</Animated.View>
 						</>
 					)}
 				</Pressable>
@@ -179,7 +178,6 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'center',
 		marginBottom: 16,
-		backgroundColor: 'transparent',
 	},
 	qrPressable: {
 		position: 'relative',
@@ -195,7 +193,6 @@ const styles = StyleSheet.create({
 		position: 'absolute',
 		top: '50%',
 		transform: [{ translateY: -16 }],
-		backgroundColor: 'transparent',
 	},
 	chevronLeft: {
 		left: -40,

--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -1,13 +1,12 @@
 import React, { memo, ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
-import { Alert, Platform, StyleSheet } from 'react-native';
+import { Alert, Platform, StyleSheet, View } from 'react-native';
 import { PubkyAuthDetails } from '@synonymdev/react-native-pubky';
-import { AnimatedView, View } from '../theme/components';
 import { SheetManager } from 'react-native-actions-sheet';
 import { performAuth } from '../utils/pubky';
 import { useDispatch, useSelector } from 'react-redux';
 import { showToast, sleep } from '../utils/helpers.ts';
 import PubkyCard from './PubkyCard.tsx';
-import { useAnimatedStyle, useSharedValue, withTiming, withSequence } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming, withSequence } from 'react-native-reanimated';
 import { copyToClipboard } from '../utils/clipboard.ts';
 import { BodySText, CaptionSBText, CaptionText } from '../theme/typography';
 import { RootState } from '../store';
@@ -34,22 +33,6 @@ interface Capability {
 	path: string;
 	permission: string;
 }
-
-const CapabilitiesList = memo(
-	({ capabilities, isAuthorized }: { capabilities: Capability[]; isAuthorized: boolean }): ReactElement => {
-		const capabilitiesCount = capabilities.length;
-		return (
-			<>
-				{capabilities.map((capability, index) => (
-					<View style={styles.permissionsSection} key={index}>
-						<Permission capability={capability} isAuthorized={isAuthorized} />
-						{index !== capabilitiesCount - 1 && <View style={styles.spacer} />}
-					</View>
-				))}
-			</>
-		);
-	},
-);
 
 const Permission = memo(
 	({ capability, isAuthorized }: { capability: Capability; isAuthorized: boolean }): ReactElement => {
@@ -197,10 +180,15 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 				<CaptionText style={styles.sectionTitle}>
 					{isAuthorized ? t('auth.grantedPermissions') : t('auth.requestedPermissions')}
 				</CaptionText>
-				<CapabilitiesList capabilities={authDetailCapabilities} isAuthorized={isAuthorized} />
+
+				<View style={styles.permissions}>
+					{authDetailCapabilities.map((capability, index) => (
+						<Permission key={index} capability={capability} isAuthorized={isAuthorized} />
+					))}
+				</View>
 			</View>
 
-			<PubkyCard name={pubkyName} publicKey={pubky} avatarSize={48} avatarStyle={styles.avatarContainer} />
+			<PubkyCard name={pubkyName} publicKey={pubky} />
 
 			{!isAuthorized && (
 				<BodySText style={styles.warningText} colorName="textTertiary">
@@ -209,9 +197,9 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 			)}
 
 			<View style={styles.imageContainer}>
-				<AnimatedView style={[styles.imageWrapper, checkStyle]}>
+				<Animated.View style={[styles.imageWrapper, checkStyle]}>
 					<CheckCircle colorName="pubkyApp" size={128} />
-				</AnimatedView>
+				</Animated.View>
 			</View>
 
 			<View style={styles.footerContainer}>
@@ -268,10 +256,12 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'flex-start',
 		alignItems: 'center',
-		backgroundColor: 'transparent',
 	},
-	permissionsSection: {
-		backgroundColor: 'transparent',
+	permissions: {
+		gap: 8,
+	},
+	sectionTitle: {
+		marginBottom: 8,
 	},
 	relayText: {
 		justifyContent: 'center',
@@ -284,54 +274,35 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'space-between',
 		alignItems: 'center',
-		backgroundColor: 'transparent',
 	},
 	pathContainer: {
 		flex: 2,
 		marginLeft: 5,
 		justifyContent: 'center',
-		backgroundColor: 'transparent',
 	},
 	permissionsContainer: {
 		flex: 1,
 		flexDirection: 'row',
 		justifyContent: 'flex-end',
 		gap: 8,
-		backgroundColor: 'transparent',
 	},
 	imageContainer: {
 		flex: 1,
 		justifyContent: 'center',
 		alignItems: 'center',
-		backgroundColor: 'transparent',
 	},
 	imageWrapper: {
 		justifyContent: 'center',
 		alignItems: 'center',
-		backgroundColor: 'transparent',
-	},
-	sectionTitle: {
-		marginBottom: 8,
-	},
-	avatarContainer: {
-		width: 48,
-		height: 48,
-		borderRadius: 24,
-		marginRight: 16,
-	},
-	spacer: {
-		marginBottom: 12,
 	},
 	footerContainer: {
 		marginTop: 'auto',
 		justifyContent: 'center',
-		backgroundColor: 'transparent',
 	},
 	buttonContainer: {
 		flexDirection: 'row',
 		alignItems: 'center',
 		gap: 16,
-		backgroundColor: 'transparent',
 	},
 	progressBarContainer: {
 		position: 'absolute',

--- a/src/components/DeletePubky.tsx
+++ b/src/components/DeletePubky.tsx
@@ -31,14 +31,7 @@ const DeletePubky = ({
 	return (
 		<Sheet id="delete-pubky" title={t('pubky.deletePubky')} gradientType="brand">
 			<BodyMText style={styles.message}>{t('pubky.deleteConfirm')}</BodyMText>
-			<PubkyCard
-				name={pubkyName}
-				publicKey={publicKey}
-				containerStyle={styles.pubkyContainer}
-				nameStyle={styles.pubkyName}
-				avatarSize={48}
-				avatarStyle={styles.avatarContainer}
-			/>
+			<PubkyCard name={pubkyName} publicKey={publicKey} />
 			<View style={styles.imageContainer}>
 				<Image source={require('../images/trash.png')} style={styles.image} />
 			</View>
@@ -53,18 +46,6 @@ const DeletePubky = ({
 const styles = StyleSheet.create({
 	message: {
 		marginBottom: 24,
-	},
-	pubkyContainer: {
-		padding: 24,
-	},
-	avatarContainer: {
-		width: 48,
-		height: 48,
-		borderRadius: 24,
-		marginRight: 16,
-	},
-	pubkyName: {
-		marginBottom: 2,
 	},
 	imageContainer: {
 		flex: 1,

--- a/src/components/ImportSuccessSheet.tsx
+++ b/src/components/ImportSuccessSheet.tsx
@@ -1,16 +1,17 @@
 import React, { memo, ReactElement, useCallback, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { SheetManager } from 'react-native-actions-sheet';
 import { useSelector } from 'react-redux';
-import PubkyReview from './PubkySetup/PubkyReview.tsx';
 import { getPubky, getPubkyCount } from '../store/selectors/pubkySelectors.ts';
 import { RootState } from '../store';
 import { useTranslation } from 'react-i18next';
 import Sheet from './Sheet.tsx';
 import { SHEET_TRANSITION_DELAY } from '../utils/constants.ts';
+import PubkyProfile from './PubkyProfile.tsx';
+import { BodyMText } from '../theme/typography.ts';
+import Button from './Button.tsx';
 
 interface ImportSuccessSheetPayload {
-	modalTitle?: string;
-	description?: string;
 	isNewPubky?: boolean;
 	pubky: string;
 	onContinue?: () => void;
@@ -19,13 +20,7 @@ interface ImportSuccessSheetPayload {
 const ImportSuccessSheet = ({ payload }: { payload: ImportSuccessSheetPayload }): ReactElement => {
 	const { t } = useTranslation();
 	const pubkyCount = useSelector(getPubkyCount);
-	const {
-		modalTitle: payloadModalTitle,
-		description: payloadDescription,
-		isNewPubky = false,
-		onContinue: onContinuePayload,
-		pubky,
-	} = payload;
+	const { isNewPubky = false, onContinue: onContinuePayload, pubky } = payload;
 
 	const pubkyData = useSelector((state: RootState) => getPubky(state, pubky));
 
@@ -40,12 +35,8 @@ const ImportSuccessSheet = ({ payload }: { payload: ImportSuccessSheetPayload })
 		}, SHEET_TRANSITION_DELAY);
 	}, [isNewPubky, onContinuePayload]);
 
-	const modalTitle = !isNewPubky
-		? t('import.pubkyReImported')
-		: (payloadModalTitle ?? t('import.pubkyImported'));
-	const description = !isNewPubky
-		? t('import.reImportSuccess')
-		: (payloadDescription ?? t('import.importSuccess'));
+	const modalTitle = !isNewPubky ? t('import.pubkyReImported') : t('import.pubkyImported');
+	const description = !isNewPubky ? t('import.reImportSuccess') : t('import.importSuccess');
 
 	const data = useMemo(() => {
 		return { ...pubkyData, pubky, name: pubkyData.name || `pubky #${pubkyCount}` };
@@ -53,9 +44,29 @@ const ImportSuccessSheet = ({ payload }: { payload: ImportSuccessSheetPayload })
 
 	return (
 		<Sheet id="import-success" title={modalTitle} gradientType="brand">
-			<PubkyReview description={description} pubky={pubky} pubkyData={data} onContinue={onContinue} />
+			<BodyMText style={styles.message}>{description}</BodyMText>
+			<PubkyProfile pubky={pubky} pubkyData={data} />
+			<View style={styles.footer}>
+				<Button
+					text={t('common.continue')}
+					size="large"
+					testID="ImportSuccessButton"
+					onPress={onContinue}
+				/>
+			</View>
 		</Sheet>
 	);
 };
+
+const styles = StyleSheet.create({
+	message: {
+		marginBottom: 24,
+	},
+	footer: {
+		marginTop: 'auto',
+		flexDirection: 'row',
+		alignItems: 'center',
+	},
+});
 
 export default memo(ImportSuccessSheet);

--- a/src/components/ProfileAvatar.tsx
+++ b/src/components/ProfileAvatar.tsx
@@ -12,29 +12,21 @@ interface ProfileAvatarProps {
 }
 
 const ProfileAvatar = ({ pubky, size = 32 }: ProfileAvatarProps): ReactElement => {
-	const publicKey = useMemo(() => {
-		if (!pubky) {
-			return '';
-		}
-		return pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
-	}, [pubky]);
-
+	const publicKey = pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
 	const imageUri = useSelector((state: RootState) => getPubkyImage(state, publicKey));
-
-	const borderRadius = useMemo(() => size / 2, [size]);
 
 	// Memoize style object to prevent unnecessary re-renders
 	const imageStyle = useMemo(
 		() => ({
 			width: size,
 			height: size,
-			borderRadius,
+			borderRadius: '50%',
 		}),
-		[size, borderRadius],
+		[size],
 	);
 
 	// Memoize SVG generation - expensive string operation
-	const svg = useMemo(() => jdenticon.toSvg(pubky, size), [pubky, size]);
+	const svg = useMemo(() => jdenticon.toSvg(pubky, size, { padding: 0 }), [pubky, size]);
 
 	if (imageUri) {
 		return <Image source={{ uri: imageUri }} style={imageStyle} />;

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -1,23 +1,14 @@
-import React, { memo, ReactElement, useCallback, useMemo } from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import React, { memo, ReactElement, useCallback } from 'react';
+import { Platform, StyleSheet, View, TouchableOpacity } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { EBackupPreference, Pubky } from '../types/pubky.ts';
 import { useQRScanner } from '../hooks/useQRScanner';
-import {
-	Box,
-	Card,
-	CardView,
-	ForegroundView,
-	LinearGradient,
-	NavView,
-	TouchableOpacity,
-	View,
-} from '../theme/components.ts';
+import { CardGradient } from '../theme/components.ts';
 import { truncateStr } from '../utils/pubky.ts';
 import ProfileAvatar from './ProfileAvatar.tsx';
 import { BodySSBText, HeadingText } from '../theme/typography';
 import { usePubkyHandlers } from '../hooks/usePubkyHandlers';
 import { showEditPubkySheet, showBackupPrompt } from '../utils/sheetHelpers.ts';
-import i18n from '../i18n';
 import Button from './Button.tsx';
 import { ChevronRight, Scan } from '../icons/index.ts';
 
@@ -29,29 +20,34 @@ interface PubkyInfoProps {
 }
 
 const PubkyInfo = memo(({ pubkyName, publicKey, sessionsCount, isBackedUp }: PubkyInfoProps) => {
+	const { t } = useTranslation();
+
 	const handleBackupPress = useCallback(() => {
 		showBackupPrompt({ pubky: publicKey, backupPreference: EBackupPreference.unknown });
 	}, [publicKey]);
+
 	return (
 		<View style={styles.contentContainer}>
 			<HeadingText style={styles.nameText} numberOfLines={1}>
 				{pubkyName}
 			</HeadingText>
-			<Card style={styles.row}>
+			<View style={styles.row}>
 				<BodySSBText numberOfLines={1} ellipsizeMode="middle">
 					{truncateStr(publicKey)}
 				</BodySSBText>
 				{!isBackedUp && (
 					<TouchableOpacity onPress={handleBackupPress} style={styles.backupContainer}>
-						<BodySSBText colorName="pubkyRing">{i18n.t('pubkyProfile.backupReminder')}</BodySSBText>
+						<BodySSBText style={styles.backupText} colorName="pubkyRing">
+							{t('pubkyProfile.backupReminder')}
+						</BodySSBText>
 					</TouchableOpacity>
 				)}
 				{sessionsCount > 0 && (
-					<CardView style={styles.sessionsButton}>
+					<View style={styles.sessionsButton}>
 						<BodySSBText colorName="textTertiary">{sessionsCount}</BodySSBText>
-					</CardView>
+					</View>
 				)}
-			</Card>
+			</View>
 		</View>
 	);
 });
@@ -75,6 +71,7 @@ const PubkyBox = ({
 	disabled,
 	loading = false,
 }: PubkyBoxProps): ReactElement => {
+	const { t } = useTranslation();
 	const { handleQRPress, isQRLoading } = useQRScanner();
 	const { onQRPress, onPubkyPress } = usePubkyHandlers();
 
@@ -86,20 +83,17 @@ const PubkyBox = ({
 		onPubkyPress(pubky, index ?? 0);
 	}, [index, onPubkyPress, pubky]);
 
-	const publicKey = useMemo(() => (pubky.startsWith('pk:') ? pubky.slice(3) : pubky), [pubky]);
-
-	const pubkyName = useMemo(() => {
-		return (
-			truncateStr(pubkyData.name, 8) || `${i18n.t('emptyState.placeholderName')} #${index ? index + 1 : 1}`
-		);
-	}, [index, pubkyData.name]);
+	const publicKey = pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
+	const pubkyName =
+		truncateStr(pubkyData.name, 8) ||
+		`${t('emptyState.placeholderName')} #${index !== undefined ? index + 1 : 1}`;
 
 	const qrPress = useCallback(() => {
 		if (pubkyData.signedUp) {
 			handleQRAction();
 		} else {
 			showEditPubkySheet({
-				title: i18n.t('pubky.setup'),
+				title: t('pubky.setup'),
 				description: '',
 				pubky: pubky,
 				data: pubkyData,
@@ -108,33 +102,29 @@ const PubkyBox = ({
 	}, [handleQRAction, pubky, pubkyData]);
 
 	// testId example: PubkyBox-StagingTestPubky-0
-	const pubkyBoxTestID = useMemo(() => {
-		const sanitizedName = pubkyData.name.replace(/[^a-zA-Z0-9]/g, '');
-		const indexStr = index !== undefined ? `-${index}` : '';
-		return `PubkyBox-${sanitizedName}${indexStr}`;
-	}, [pubkyData.name, index]);
+	const sanitizedName = pubkyData.name.replace(/[^a-zA-Z0-9]/g, '');
+	const indexStr = index !== undefined ? `-${index}` : '';
+	const pubkyBoxTestID = `PubkyBox-${sanitizedName}${indexStr}`;
 
 	return (
-		<LinearGradient testID={pubkyBoxTestID} style={styles.container}>
+		<CardGradient testID={pubkyBoxTestID} style={styles.container}>
 			<TouchableOpacity
 				style={styles.wrapper}
 				activeOpacity={0.7}
 				onPress={handleOnPress}
 				onLongPress={onLongPress}
 			>
-				<Box
-					onPress={handleOnPress}
-					onLongPress={onLongPress}
+				<TouchableOpacity
+					style={styles.box}
 					disabled={disabled}
 					hitSlop={40}
-					style={styles.box}
 					activeOpacity={0.7}
+					onPress={handleOnPress}
+					onLongPress={onLongPress}
 				>
-					<ForegroundView style={styles.profileImageContainer}>
-						<NavView style={styles.profileImage}>
-							<ProfileAvatar pubky={publicKey} size={48} />
-						</NavView>
-					</ForegroundView>
+					<View style={styles.profileImage}>
+						<ProfileAvatar pubky={publicKey} size={48} />
+					</View>
 
 					<PubkyInfo
 						pubkyName={pubkyName}
@@ -143,14 +133,14 @@ const PubkyBox = ({
 						sessionsCount={sessionsCount}
 					/>
 
-					<ForegroundView style={styles.buttonArrow}>
+					<View style={styles.iconContainer}>
 						<ChevronRight size={24} colorName="textTertiary" />
-					</ForegroundView>
-				</Box>
+					</View>
+				</TouchableOpacity>
 
 				<Button
 					style={styles.button}
-					text={pubkyData.signedUp ? i18n.t('auth.authorize') : i18n.t('pubky.setup')}
+					text={pubkyData.signedUp ? t('auth.authorize') : t('pubky.setup')}
 					size="medium"
 					variant="secondary"
 					loading={isQRLoading || loading}
@@ -159,7 +149,7 @@ const PubkyBox = ({
 					onLongPress={onLongPress}
 				/>
 			</TouchableOpacity>
-		</LinearGradient>
+		</CardGradient>
 	);
 };
 
@@ -171,64 +161,54 @@ const styles = StyleSheet.create({
 	},
 	wrapper: {
 		padding: 24,
-		backgroundColor: 'transparent',
 	},
 	box: {
-		backgroundColor: 'transparent',
 		flexDirection: 'row',
 		alignItems: 'center',
-	},
-	profileImageContainer: {
-		marginRight: 16,
-		backgroundColor: 'transparent',
 	},
 	profileImage: {
 		width: 48,
 		height: 48,
-		borderRadius: 30,
+		borderRadius: '50%',
 		overflow: 'hidden',
 		justifyContent: 'center',
 		alignItems: 'center',
+		marginRight: 16,
 	},
 	contentContainer: {
 		flex: 1,
 		justifyContent: 'center',
 		alignItems: 'flex-start',
-		backgroundColor: 'transparent',
 	},
 	nameText: {
-		...Platform.select({
-			android: {
-				paddingBottom: 4,
-			},
-		}),
+		paddingRight: 16,
 	},
-	buttonArrow: {
-		backgroundColor: 'transparent',
-		display: 'flex',
+	iconContainer: {
 		justifyContent: 'center',
 		marginLeft: 'auto',
 	},
 	sessionsButton: {
-		borderRadius: 100,
+		alignItems: 'center',
 		height: 20,
 		width: 20,
-		alignContent: 'center',
-		justifyContent: 'center',
-		marginLeft: 4,
+		borderRadius: '50%',
+		marginLeft: 8,
+		backgroundColor: 'rgba(255, 255, 255, 0.16)',
 	},
 	row: {
 		flexDirection: 'row',
-		backgroundColor: 'transparent',
 		flexWrap: 'nowrap',
 	},
 	backupContainer: {
-		paddingHorizontal: 8,
-		paddingVertical: 2,
+		alignItems: 'center',
 		backgroundColor: 'rgba(0, 133, 255, 0.16)',
 		borderRadius: 16,
-		marginLeft: 5,
-		alignSelf: 'center',
+		paddingHorizontal: 8,
+		marginLeft: 8,
+		height: 20,
+	},
+	backupText: {
+		letterSpacing: 0,
 	},
 	button: {
 		marginTop: 24,

--- a/src/components/PubkyCard.tsx
+++ b/src/components/PubkyCard.tsx
@@ -1,72 +1,71 @@
-import { StyleSheet, StyleProp, ViewStyle, TextStyle } from 'react-native';
-import { Card, LinearGradient } from '../theme/components.ts';
+import { StyleSheet, StyleProp, ViewStyle, View } from 'react-native';
+import { CardGradient } from '../theme/components.ts';
 import React, { memo, ReactElement } from 'react';
 import ProfileAvatar from './ProfileAvatar.tsx';
 import { BodySSBText, HeadingText } from '../theme/typography';
 import { truncatePubky } from '../utils/pubky.ts';
+import { ChevronRight } from '../icons/index.ts';
 
 interface PubkyCardProps {
-	name?: string;
 	publicKey: string;
+	name?: string;
 	style?: StyleProp<ViewStyle>;
-	containerStyle?: StyleProp<ViewStyle>;
-	nameStyle?: StyleProp<TextStyle>;
-	pubkyTextStyle?: StyleProp<TextStyle>;
 	avatarSize?: number;
-	avatarStyle?: StyleProp<ViewStyle>;
+	showChevron?: boolean;
 }
 
 const PubkyCard = ({
-	name,
 	publicKey,
+	name,
 	style,
-	containerStyle,
-	nameStyle,
-	pubkyTextStyle,
-	avatarSize = 38,
-	avatarStyle,
+	avatarSize = 48,
+	showChevron = false,
 }: PubkyCardProps): ReactElement => {
 	return (
-		<LinearGradient style={[styles.pubkyCard, style]}>
-			<Card style={[styles.pubkyRow, containerStyle]}>
-				<Card style={[styles.iconContainer, avatarStyle]}>
+		<CardGradient style={[styles.container, style]}>
+			<View style={styles.row}>
+				<View style={styles.avatar}>
 					<ProfileAvatar pubky={publicKey} size={avatarSize} />
-				</Card>
-				<Card style={styles.pubkyTextContainer}>
-					{name && <HeadingText style={nameStyle}>{name}</HeadingText>}
-					<BodySSBText style={pubkyTextStyle} numberOfLines={2}>
-						{truncatePubky(publicKey)}
-					</BodySSBText>
-				</Card>
-			</Card>
-		</LinearGradient>
+				</View>
+				<View style={styles.text}>
+					{name && (
+						<HeadingText style={styles.name} numberOfLines={1}>
+							{name}
+						</HeadingText>
+					)}
+					<BodySSBText numberOfLines={1}>{truncatePubky(publicKey)}</BodySSBText>
+				</View>
+
+				{showChevron && <ChevronRight colorName="textTertiary" />}
+			</View>
+		</CardGradient>
 	);
 };
 
 const styles = StyleSheet.create({
-	pubkyCard: {
+	container: {
 		borderRadius: 16,
 		minHeight: 96,
 	},
-	pubkyRow: {
+	row: {
 		flex: 1,
 		flexDirection: 'row',
 		alignItems: 'center',
-		alignSelf: 'center',
-		justifyContent: 'center',
 		paddingHorizontal: 24,
-		backgroundColor: 'transparent',
 	},
-	iconContainer: {
-		width: 38,
-		height: 38,
+	avatar: {
+		width: 48,
+		height: 48,
 		marginRight: 16,
 		borderRadius: '50%',
-		// overflow: 'hidden',
+		overflow: 'hidden',
 	},
-	pubkyTextContainer: {
+	text: {
 		flex: 1,
-		backgroundColor: 'transparent',
+		paddingRight: 16,
+	},
+	name: {
+		marginBottom: 2,
 	},
 });
 

--- a/src/components/PubkyDetail/PubkyDetail.tsx
+++ b/src/components/PubkyDetail/PubkyDetail.tsx
@@ -1,8 +1,8 @@
-import React, { memo, ReactElement, useCallback, useMemo } from 'react';
+import React, { memo, ReactElement, useCallback } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
 import { deletePubky, signOutOfHomeserver } from '../../utils/pubky.ts';
 import { useDispatch } from 'react-redux';
-import PubkyListHeader from './PubkyListHeader.tsx';
+import PubkyDetailCard from './PubkyDetailCard';
 import { PubkyData } from '../../navigation/types.ts';
 import { showToast } from '../../utils/helpers.ts';
 import { showBackupPrompt } from '../../utils/sheetHelpers.ts';
@@ -20,7 +20,7 @@ export interface PubkyDetailProps {
 
 export const PubkyDetail = ({ index, pubkyData, onQRPress }: PubkyDetailProps): ReactElement => {
 	const { pubky, sessions } = pubkyData;
-	const publicKey = useMemo(() => (pubky.startsWith('pk:') ? pubky.slice(3) : pubky), [pubky]);
+	const publicKey = pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
 	const dispatch = useDispatch();
 	const navigation = useTypedNavigation();
 
@@ -67,7 +67,7 @@ export const PubkyDetail = ({ index, pubkyData, onQRPress }: PubkyDetailProps): 
 		}
 	}, [pubky, pubkyData.backupPreference]);
 
-	const sessionsLength = useMemo(() => (sessions && sessions?.length > 0 ? sessions.length : 1), [sessions]);
+	const sessionsLength = sessions?.length > 0 ? sessions.length : 1;
 
 	return (
 		<View style={styles.container}>
@@ -77,7 +77,7 @@ export const PubkyDetail = ({ index, pubkyData, onQRPress }: PubkyDetailProps): 
 				bounces={false}
 				nestedScrollEnabled={true}
 			>
-				<PubkyListHeader
+				<PubkyDetailCard
 					index={index}
 					pubky={pubky}
 					pubkyData={pubkyData}

--- a/src/components/PubkyDetail/PubkyDetailCard.tsx
+++ b/src/components/PubkyDetail/PubkyDetailCard.tsx
@@ -1,15 +1,14 @@
-import React, { memo, useCallback, useMemo, useState } from 'react';
-import { PixelRatio, StyleSheet } from 'react-native';
+import React, { memo, useCallback, useState } from 'react';
+import { PixelRatio, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { PubkyData } from '../../navigation/types.ts';
-import { View, LinearGradient } from '../../theme/components.ts';
 import Button from '../Button.tsx';
 import { shareData } from '../../utils/helpers.ts';
 import { showEditPubkySheet } from '../../utils/sheetHelpers.ts';
 import PubkyProfile from '../PubkyProfile.tsx';
 import { Scan, Share, Shield, Trash } from '../../icons/index.ts';
 
-interface PubkyListHeaderProps {
+interface PubkyDetailCardProps {
 	index: number;
 	pubky: string;
 	pubkyData: PubkyData;
@@ -18,13 +17,13 @@ interface PubkyListHeaderProps {
 	onBackup: () => void;
 }
 
-export const PubkyListHeader = memo(
-	({ index, pubky, pubkyData, onQRPress, onDelete, onBackup }: PubkyListHeaderProps) => {
+export const PubkyDetailCard = memo(
+	({ index, pubky, pubkyData, onQRPress, onDelete, onBackup }: PubkyDetailCardProps) => {
 		const { t } = useTranslation();
 		const [fontScale] = useState(PixelRatio.getFontScale());
 		const [isQRLoading, setIsQRLoading] = useState(false);
 
-		const pubkyUri = useMemo(() => (pubky.startsWith('pk:') ? pubky.slice(3) : pubky), [pubky]);
+		const pubkyUri = pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
 		const onSharePress = useCallback(() => {
 			shareData(pubkyUri).then();
 		}, [pubkyUri]);
@@ -56,17 +55,15 @@ export const PubkyListHeader = memo(
 
 		return (
 			<View style={styles.container}>
-				<LinearGradient style={styles.profileSection}>
-					<PubkyProfile
-						index={index}
-						pubky={pubky}
-						pubkyData={pubkyData}
-						onButtonPress={handleButtonPress}
-						buttonText={buttonText}
-						buttonIcon={buttonIcon}
-						isButtonLoading={isQRLoading}
-					/>
-				</LinearGradient>
+				<PubkyProfile
+					index={index}
+					pubky={pubky}
+					pubkyData={pubkyData}
+					buttonText={buttonText}
+					buttonIcon={buttonIcon}
+					isButtonLoading={isQRLoading}
+					onButtonPress={handleButtonPress}
+				/>
 
 				<View style={styles.actionButtonRow}>
 					<Button
@@ -96,22 +93,16 @@ export const PubkyListHeader = memo(
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		alignItems: 'center',
-		marginHorizontal: 20,
+		marginHorizontal: 24,
 	},
 	actionButtonRow: {
 		flexDirection: 'row',
 		gap: 6,
 		marginTop: 24,
-		width: '100%',
 	},
 	actionButton: {
 		flex: 1,
 	},
-	profileSection: {
-		width: '100%',
-		borderRadius: 16,
-	},
 });
 
-export default PubkyListHeader;
+export default PubkyDetailCard;

--- a/src/components/PubkyDetail/SessionItem.tsx
+++ b/src/components/PubkyDetail/SessionItem.tsx
@@ -1,9 +1,11 @@
+// Currently not used
+
 import React, { memo, ReactElement, useCallback, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { PubkySession } from '../../types/pubky.ts';
 import { BodySSBText, BodySText, CaptionSBSpacedText } from '../../theme/typography';
-import { SessionView, TouchableOpacity, SessionBox } from '../../theme/components.ts';
+import { TouchableOpacity, CardGradient } from '../../theme/components.ts';
 
 const formatTimestamp = (timestamp: number): string => {
 	const date = new Date(timestamp);
@@ -34,36 +36,41 @@ const SessionItem = ({
 	}, [onSignOut, session.session_secret]);
 
 	return (
-		<SessionBox style={styles.sessionCard}>
-			<SessionView style={styles.headerRow}>
-				<SessionView style={styles.infoContainer}>
+		<CardGradient style={styles.sessionCard}>
+			<View style={styles.headerRow}>
+				<View style={styles.infoContainer}>
 					<BodySSBText style={styles.pubkyText} numberOfLines={1}>
 						{session.pubky}
 					</BodySSBText>
 					<BodySText colorName="textTertiary" style={styles.dateText}>
 						{formattedDate}
 					</BodySText>
-				</SessionView>
+				</View>
 				<TouchableOpacity style={styles.signOutButton} onPress={handleSignOut} activeOpacity={0.7}>
-					<CaptionSBSpacedText colorName="danger" numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.8}>
+					<CaptionSBSpacedText
+						colorName="danger"
+						numberOfLines={1}
+						adjustsFontSizeToFit
+						minimumFontScale={0.8}
+					>
 						{t('sessionItem.signOut')}
 					</CaptionSBSpacedText>
 				</TouchableOpacity>
-			</SessionView>
+			</View>
 
 			{session.capabilities?.length > 0 && (
-				<SessionView style={styles.capsContainer}>
+				<View style={styles.capsContainer}>
 					<CaptionSBSpacedText style={styles.capsTitle}>{t('sessionItem.capabilities')}</CaptionSBSpacedText>
-					<SessionView style={styles.capsWrapper}>
+					<View style={styles.capsWrapper}>
 						{session.capabilities.map(cap => (
-							<SessionView key={cap} style={styles.capChip}>
+							<View key={cap} style={styles.capChip}>
 								<BodySText>{cap}</BodySText>
-							</SessionView>
+							</View>
 						))}
-					</SessionView>
-				</SessionView>
+					</View>
+				</View>
 			)}
-		</SessionBox>
+		</CardGradient>
 	);
 };
 

--- a/src/components/PubkyProfile.tsx
+++ b/src/components/PubkyProfile.tsx
@@ -1,11 +1,11 @@
-import React, { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import React, { memo, useCallback } from 'react';
+import { StyleProp, StyleSheet, View, TouchableOpacity, ViewStyle } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { copyToClipboard } from '../utils/clipboard';
 import { PubkyData } from '../navigation/types';
-import { View, Card } from '../theme/components';
+import { CardGradient } from '../theme/components';
 import { isSmallScreen, showToast } from '../utils/helpers';
 import ProfileAvatar from './ProfileAvatar';
-import i18n from '../i18n';
 import { BodyMSBText, HeadingText } from '../theme/typography';
 import Button from './Button.tsx';
 
@@ -13,11 +13,12 @@ interface PubkyProfileProps {
 	index?: number;
 	pubky: string;
 	pubkyData: PubkyData;
-	onButtonPress?: () => void;
 	hideButton?: boolean;
 	buttonText?: string;
 	buttonIcon?: React.ReactNode;
 	isButtonLoading?: boolean;
+	style?: StyleProp<ViewStyle>;
+	onButtonPress?: () => void;
 }
 
 const smallScreen = isSmallScreen();
@@ -28,36 +29,33 @@ export const PubkyProfile = memo(
 		index,
 		pubky,
 		pubkyData,
-		onButtonPress,
-		hideButton = false,
 		buttonText,
 		buttonIcon,
 		isButtonLoading = false,
+		style,
+		onButtonPress,
 	}: PubkyProfileProps) => {
+		const { t } = useTranslation();
+
 		const handleCopyPubky = useCallback(() => {
 			copyToClipboard(pubky);
 			showToast({
 				type: 'info',
-				title: i18n.t('clipboard.pubkyCopied'),
-				description: i18n.t('clipboard.pubkyCopiedDescription'),
+				title: t('clipboard.pubkyCopied'),
+				description: t('clipboard.pubkyCopiedDescription'),
 			});
 		}, [pubky]);
 
-		const pubkyUri = useMemo(() => (pubky.startsWith('pk:') ? pubky.slice(3) : pubky), [pubky]);
-
-		const pubkyName = useMemo(() => {
-			if (pubkyData?.name) {
-				return pubkyData.name;
-			}
-			if (index !== undefined) {
-				return `${i18n.t('emptyState.placeholderName')} #${index + 1}`;
-			}
-			return i18n.t('emptyState.placeholderName');
-		}, [index, pubkyData.name]);
+		const pubkyUri = pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
+		const pubkyName =
+			pubkyData.name ||
+			(index !== undefined
+				? `${t('emptyState.placeholderName')} #${index + 1}`
+				: t('emptyState.placeholderName'));
 
 		return (
-			<View style={[styles.profileContainer, smallScreenStyle]}>
-				<Card style={styles.profile}>
+			<CardGradient style={[styles.gradient, style]}>
+				<View style={[styles.profileContainer, smallScreenStyle]}>
 					<View style={styles.avatarContainer}>
 						<ProfileAvatar pubky={pubky} size={96} />
 					</View>
@@ -67,55 +65,51 @@ export const PubkyProfile = memo(
 					<TouchableOpacity activeOpacity={0.7} onPress={handleCopyPubky}>
 						<BodyMSBText style={styles.pubkyText}>{pubkyUri}</BodyMSBText>
 					</TouchableOpacity>
-				</Card>
 
-				{!hideButton && (
-					<Button
-						text={buttonText ?? ''}
-						size="large"
-						variant="secondary"
-						icon={buttonIcon}
-						loading={isButtonLoading}
-						onPress={onButtonPress}
-					/>
-				)}
-			</View>
+					{onButtonPress && (
+						<Button
+							style={styles.button}
+							text={buttonText ?? ''}
+							size="large"
+							variant="secondary"
+							icon={buttonIcon}
+							loading={isButtonLoading}
+							onPress={onButtonPress}
+						/>
+					)}
+				</View>
+			</CardGradient>
 		);
 	},
 );
 
 const styles = StyleSheet.create({
-	container: {
-		alignItems: 'center',
+	gradient: {
 		borderRadius: 16,
 	},
 	profileContainer: {
+		alignItems: 'center',
 		padding: 36,
-		backgroundColor: 'transparent',
-	},
-	profile: {
-		paddingBottom: 16,
-		backgroundColor: 'transparent',
 	},
 	avatarContainer: {
 		width: 96,
 		height: 96,
-		borderRadius: 60,
+		borderRadius: '50%',
 		overflow: 'hidden',
 		justifyContent: 'center',
 		alignItems: 'center',
-		alignSelf: 'center',
-		backgroundColor: 'transparent',
 		marginBottom: 16,
 	},
 	nameText: {
-		paddingBottom: 12,
+		paddingBottom: 16,
 		textAlign: 'center',
-		backgroundColor: 'transparent',
 	},
 	pubkyText: {
 		textAlign: 'center',
-		marginBottom: 8,
+	},
+	button: {
+		width: '100%',
+		marginTop: 16,
 	},
 });
 

--- a/src/components/PubkySetup/PubkyReview.tsx
+++ b/src/components/PubkySetup/PubkyReview.tsx
@@ -1,14 +1,13 @@
 import React, { ReactElement } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { ForegroundView } from '../../theme/components.ts';
+import { useTranslation } from 'react-i18next';
 import PubkyProfile from '../PubkyProfile.tsx';
 import { PubkyData } from '../../navigation/types.ts';
-import i18n from '../../i18n';
 import { BodyMText, DisplayText } from '../../theme/typography';
 import Button from '../Button.tsx';
 
 interface PubkyReviewProps {
-	headerText?: string;
+	headerText: string;
 	description: string;
 	pubky: string;
 	pubkyData: PubkyData;
@@ -22,16 +21,16 @@ const PubkyReview = ({
 	pubkyData,
 	onContinue,
 }: PubkyReviewProps): ReactElement => {
+	const { t } = useTranslation();
+
 	return (
 		<View style={styles.content}>
-			{headerText && <DisplayText style={styles.headerText}>{headerText}</DisplayText>}
+			<DisplayText style={styles.headerText}>{headerText}</DisplayText>
 			<BodyMText style={styles.message}>{description}</BodyMText>
-			<ForegroundView style={styles.profileCard}>
-				<PubkyProfile pubky={pubky} pubkyData={pubkyData} hideButton={true} />
-			</ForegroundView>
+			<PubkyProfile pubky={pubky} pubkyData={pubkyData} />
 			<View style={styles.footer}>
 				<Button
-					text={i18n.t('common.continue')}
+					text={t('common.continue')}
 					size="large"
 					variant="secondary"
 					testID="NewPubkyContinueButton"
@@ -51,12 +50,6 @@ const styles = StyleSheet.create({
 	},
 	message: {
 		marginBottom: 24,
-	},
-	profileCard: {
-		alignItems: 'center',
-		justifyContent: 'center',
-		borderRadius: 24,
-		backgroundColor: 'rgba(255, 255, 255, 0.05)',
 	},
 	footer: {
 		marginTop: 'auto',

--- a/src/components/SelectPubky.tsx
+++ b/src/components/SelectPubky.tsx
@@ -72,12 +72,12 @@ const SelectPubky = ({
 					data={pubkyArray}
 					renderItem={({ item }) => (
 						<TouchableOpacity style={styles.card} onPress={() => onPubkyPress(item.key)}>
-							<PubkyCard publicKey={item.key} name={item.value.name} />
+							<PubkyCard publicKey={item.key} name={item.value.name} showChevron={true} />
 						</TouchableOpacity>
 					)}
 					renderScrollComponent={ActionSheetScrollView}
 					keyExtractor={item => item.key}
-					showsVerticalScrollIndicator={true}
+					showsVerticalScrollIndicator={false}
 				/>
 			</View>
 

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -36,8 +36,6 @@ const RootNavigator = (): ReactElement => {
 			colors: {
 				...DefaultTheme.colors,
 				background: theme.colors.background,
-				border: theme.colors.border,
-				card: theme.colors.cardBackground,
 				primary: theme.colors.textPrimary,
 				text: theme.colors.textPrimary,
 			},

--- a/src/screens/About.tsx
+++ b/src/screens/About.tsx
@@ -1,6 +1,5 @@
 import React, { memo, ReactElement } from 'react';
-import { Image, Linking, StyleSheet, TouchableOpacity } from 'react-native';
-import { View, ScrollView } from '../theme/components.ts';
+import { Image, Linking, StyleSheet, TouchableOpacity, ScrollView, View } from 'react-native';
 import AppHeader, { HEADER_HEIGHT } from '../components/AppHeader.tsx';
 import { version } from '../../package.json';
 import PubkyRingLogo from '../images/pubky-app-logo.png';
@@ -74,7 +73,7 @@ const About = (): ReactElement => {
 				<Image source={BrandEndoresment} style={styles.brandLogo} />
 
 				<TouchableOpacity style={styles.footer} activeOpacity={0.8} onPress={onFooterPress}>
-					<View style={styles.logo}>
+					<View>
 						<Image source={PubkyRingLogo} style={styles.pubkyLogo} />
 						<BodyMSBText colorName="pubkyApp" style={styles.footerText}>
 							{t('about.joinWithPubkyRing')}
@@ -97,7 +96,6 @@ const styles = StyleSheet.create({
 	scrollContent: {
 		flexGrow: 1,
 		paddingTop: HEADER_HEIGHT + 24,
-		backgroundColor: 'transparent',
 	},
 	lowerTitle: {
 		marginBottom: 8,
@@ -110,12 +108,8 @@ const styles = StyleSheet.create({
 		justifyContent: 'space-between',
 		alignItems: 'center',
 		height: 51,
-		backgroundColor: 'transparent',
 		borderBottomWidth: 1,
 		borderBottomColor: 'rgba(255, 255, 255, 0.1)',
-	},
-	logo: {
-		backgroundColor: 'transparent',
 	},
 	footer: {
 		flexDirection: 'row',
@@ -145,14 +139,12 @@ const styles = StyleSheet.create({
 		height: 36,
 		width: 110,
 		resizeMode: 'contain',
-		backgroundColor: 'transparent',
 	},
 	brandLogo: {
 		height: 24,
 		width: 214,
 		alignSelf: 'flex-start',
 		resizeMode: 'contain',
-		backgroundColor: 'transparent',
 		marginVertical: 24,
 	},
 });

--- a/src/screens/PubkyDetailScreen.tsx
+++ b/src/screens/PubkyDetailScreen.tsx
@@ -1,5 +1,4 @@
 import React, { memo, ReactElement, useCallback, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
 import { PubkyData } from '../navigation/types';
 import PubkyDetail from '../components/PubkyDetail/PubkyDetail.tsx';
 import { useSelector } from 'react-redux';
@@ -48,13 +47,5 @@ const PubkyDetailScreen = (): ReactElement => {
 		</SafeAreaView>
 	);
 };
-
-const styles = StyleSheet.create({
-	pencilIcon: {
-		width: 24,
-		height: 24,
-		alignSelf: 'center',
-	},
-});
 
 export default memo(PubkyDetailScreen);

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,8 +1,8 @@
 import React, { memo, ReactElement, useCallback, useMemo, useState } from 'react';
-import { Alert, StyleSheet, Switch, TouchableOpacity } from 'react-native';
+import { Alert, StyleSheet, View, Switch, TouchableOpacity } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
-import { View, Card } from '../theme/components.ts';
+import { View as ThemedView } from '../theme/components.ts';
 import AppHeader, { HEADER_HEIGHT } from '../components/AppHeader.tsx';
 import Button from '../components/Button.tsx';
 import { useDispatch, useSelector } from 'react-redux';
@@ -156,20 +156,20 @@ const SettingsScreen = ({ navigation, route }: Props): ReactElement => {
 			<View style={styles.content}>
 				{/**
                  TODO: Adjust light-mode gradient colors.
-                 <Card style={styles.section}>
+                 <ThemedView style={styles.section} colorName="buttonBackground">
                  <TouchableOpacity onPress={handleThemePress} style={styles.themeButton}>
                  <BodyMSBText>Theme</BodyMSBText>
                  <BodySText colorName="textTertiary">
                  {themeDisplayText}
                  </BodySText>
                  </TouchableOpacity>
-                 </Card>
+                 </ThemedView>
                  **/}
 
-				<Card style={styles.textSection}>
+				<View style={styles.textSection}>
 					<CaptionText>{t('settings.migrateToOtherDevice')}</CaptionText>
 					<BodyMText style={styles.textSettingValue}>{t('settings.migrateDescription')}</BodyMText>
-				</Card>
+				</View>
 
 				<View style={styles.buttonContainer}>
 					{hasPubkys && (
@@ -193,7 +193,7 @@ const SettingsScreen = ({ navigation, route }: Props): ReactElement => {
 				</View>
 
 				{showSecretSettings && (
-					<Card style={styles.section}>
+					<ThemedView style={styles.section} colorName="buttonBackground">
 						<TouchableOpacity
 							onPress={handleNavigationAnimationPress}
 							style={styles.navigationAnimationButton}
@@ -201,46 +201,46 @@ const SettingsScreen = ({ navigation, route }: Props): ReactElement => {
 							<BodyMSBText>{t('settings.navigationAnimation')}</BodyMSBText>
 							<BodySText colorName="textTertiary">{navigationAnimationText}</BodySText>
 						</TouchableOpacity>
-					</Card>
+					</ThemedView>
 				)}
 
 				{showSecretSettings && (
-					<Card style={styles.section}>
+					<ThemedView style={styles.section} colorName="buttonBackground">
 						<TouchableOpacity onPress={handleAutoAuthToggle} style={styles.toggleRow}>
 							<BodyMSBText>{t('settings.autoAuth')}</BodyMSBText>
 							<View style={styles.switchContainer}>
 								<Switch value={enableAutoAuth} onValueChange={handleAutoAuthToggle} />
 							</View>
 						</TouchableOpacity>
-					</Card>
+					</ThemedView>
 				)}
 
 				{showSecretSettings && (
-					<Card style={styles.section}>
+					<ThemedView style={styles.section} colorName="buttonBackground">
 						<TouchableOpacity onPress={handleShowOnboarding} style={styles.navigationAnimationButton}>
 							<BodyMSBText>{t('settings.showOnboarding')}</BodyMSBText>
 						</TouchableOpacity>
-					</Card>
+					</ThemedView>
 				)}
 
 				{showSecretSettings && (
-					<Card style={styles.section}>
+					<ThemedView style={styles.section} colorName="buttonBackground">
 						<TouchableOpacity onPress={handleWipePubkyRing} style={styles.navigationAnimationButton}>
 							<BodyMSBText>{t('settings.wipePubkyRing')}</BodyMSBText>
 						</TouchableOpacity>
-					</Card>
+					</ThemedView>
 				)}
 
 				{/* Backup all pubkys */}
 				{/* TODO: Consider implementing a "Backup All Pubkys" feature. Backs up all pubkys with same passphrase and saves as zip file for future import
-				<Card style={styles.section}>
+				<ThemedView style={styles.section} colorName="buttonBackground">
 					<TouchableOpacity
 						onPress={handleBackupPress}
 						style={styles.backupButton}
 					>
 						<BodyMSBText>Backup All Pubkys</BodyMSBText>
 					</TouchableOpacity>
-				</Card>
+				</ThemedView>
 				*/}
 			</View>
 		</SafeAreaView>
@@ -257,7 +257,6 @@ const styles = StyleSheet.create({
 	},
 	textSection: {
 		marginBottom: 12,
-		backgroundColor: 'transparent',
 	},
 	section: {
 		marginBottom: 16,
@@ -269,7 +268,6 @@ const styles = StyleSheet.create({
 	},
 	switchContainer: {
 		justifyContent: 'center',
-		backgroundColor: 'transparent',
 	},
 	// eslint-disable-next-line react-native/no-unused-styles
 	themeButton: {

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -1,10 +1,8 @@
 import { ComponentType, RefAttributes } from 'react';
 import { TextInput as NativeTextInput, TextInputProps } from 'react-native';
 import styled from 'styled-components/native';
+import { LinearGradient } from 'react-native-linear-gradient';
 import { Theme, ThemeColorName } from './index';
-import Animated from 'react-native-reanimated';
-import { LinearGradient as _LinearGradient } from 'react-native-linear-gradient';
-import { SafeAreaProvider as _SafeAreaProvider } from 'react-native-safe-area-context';
 import { fontFamily } from './fonts';
 
 interface BackgroundColorProps {
@@ -36,54 +34,8 @@ const StyledTextInput = styled.TextInput<{ theme: Theme }>`
 
 export const TextInput = StyledTextInput as ComponentType<TextInputProps & RefAttributes<NativeTextInput>>;
 
-export const AnimatedView = styled(Animated.View)<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.background};
-	border-color: ${(props): string => props.theme.colors.textPrimary};
-`;
-
 export const TouchableOpacity = styled.TouchableOpacity<{ theme: Theme }>`
 	background-color: ${(props): string => props.theme.colors.background};
-`;
-
-export const NavView = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.navButton};
-`;
-
-export const ScrollView = styled.ScrollView<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.background};
-`;
-
-export const SessionBox = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.cardBackground};
-	border-color: ${(props): string => props.theme.colors.border};
-`;
-
-export const Card = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.buttonBackground};
-	border-color: ${(props): string => props.theme.colors.border};
-`;
-
-export const CardView = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.buttonBackground};
-`;
-
-export const SessionView = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.cardBackground};
-	border-color: ${(props): string => props.theme.colors.border};
-`;
-
-export const Box = styled.TouchableOpacity<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.foreground};
-	border-color: ${(props): string => props.theme.colors.border};
-`;
-
-export const ForegroundView = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.foreground};
-`;
-
-export const AvatarRing = styled.View<{ theme: Theme }>`
-	background-color: ${(props): string => props.theme.colors.avatarRing};
-	border-color: ${(props): string => props.theme.colors.border};
 `;
 
 export const ActivityIndicator = styled.ActivityIndicator<{ theme: Theme }>`
@@ -96,13 +48,6 @@ export const Divider = styled.View<BackgroundColorProps>`
 	width: 100%;
 `;
 
-interface LinearGradientProps {
-	colors?: string[];
-	modal?: boolean;
-	theme: Theme;
-}
-
-export const LinearGradient = styled(_LinearGradient).attrs<LinearGradientProps>(props => ({
-	colors:
-		props.colors || (props.modal ? props.theme.colors.defaultGradient : props.theme.colors.defaultGradient),
+export const CardGradient = styled(LinearGradient).attrs<{ theme: Theme }>(props => ({
+	colors: props.theme.colors.cardGradient,
 }))``;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -12,15 +12,11 @@ export interface Theme {
 
 		// UI colors
 		background: string;
-		cardBackground: string;
-		foreground: string;
-		border: string;
-		avatarRing: string;
 		buttonBackground: string;
 		buttonBorder: string;
-		navButton: string;
-		gradient: string[];
-		defaultGradient: string[];
+		cardGradient: string[];
+		toastBackground: string;
+		toastBorder: string;
 	};
 }
 
@@ -38,18 +34,14 @@ export const lightTheme: Theme = {
 	colors: {
 		...accentColors,
 		background: '#fff',
-		cardBackground: '#f8f8f8',
-		foreground: '#f0f0f0',
 		textPrimary: '#333',
 		textSecondary: '#666',
 		textTertiary: '#999',
-		border: '#ddd',
-		avatarRing: '#f5f5f5',
 		buttonBackground: '#f5f5f5',
 		buttonBorder: '#ddd',
-		navButton: '#fff',
-		gradient: ['#f8f8f8', '#f8f8f8'],
-		defaultGradient: ['rgba(255, 255, 255, 0.12)', 'rgba(255, 255, 255, 0.08)'],
+		cardGradient: ['rgba(255, 255, 255, 0.12)', 'rgba(255, 255, 255, 0.08)'],
+		toastBackground: '#f8f8f8',
+		toastBorder: '#ddd',
 	},
 };
 
@@ -57,17 +49,13 @@ export const darkTheme: Theme = {
 	colors: {
 		...accentColors,
 		background: '#000',
-		cardBackground: '#333333',
-		foreground: '#202020',
 		textPrimary: '#fff',
 		textSecondary: 'rgba(255, 255, 255, 0.80)',
 		textTertiary: 'rgba(255, 255, 255, 0.64)',
-		border: '#444',
-		avatarRing: '#303030',
 		buttonBackground: 'rgba(255, 255, 255, 0.1)',
 		buttonBorder: 'rgba(255, 255, 255, 0.32)',
-		navButton: '#202020',
-		gradient: ['#292929', '#262626', '#222222', '#1E1E1E', '#1A1A1A'],
-		defaultGradient: ['rgba(255, 255, 255, 0.12)', 'rgba(255, 255, 255, 0.08)'],
+		cardGradient: ['rgba(255, 255, 255, 0.12)', 'rgba(255, 255, 255, 0.08)'],
+		toastBackground: '#333333',
+		toastBorder: '#444',
 	},
 };

--- a/src/theme/toastConfig.tsx
+++ b/src/theme/toastConfig.tsx
@@ -12,22 +12,22 @@ interface ThemedProps {
 }
 
 const StyledBaseToast = styled(BaseToast)<ThemedProps>`
-	background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
-	border-left-color: ${(props: ThemedProps): string => props.theme.colors.border};
+	background-color: ${(props: ThemedProps): string => props.theme.colors.toastBackground};
+	border-left-color: ${(props: ThemedProps): string => props.theme.colors.toastBorder};
 `;
 
 const StyledErrorToast = styled(ErrorToast)<ThemedProps>`
-	background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
+	background-color: ${(props: ThemedProps): string => props.theme.colors.toastBackground};
 	border-left-color: #FF0000;
 `;
 
 const StyledSuccessToast = styled(SuccessToast)<ThemedProps>`
-	background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
+	background-color: ${(props: ThemedProps): string => props.theme.colors.toastBackground};
 	border-left-color: #16a34a;
 `;
 
 const StyledInfoToast = styled(InfoToast)<ThemedProps>`
-	background-color: ${(props: ThemedProps): string => props.theme.colors.cardBackground};
+	background-color: ${(props: ThemedProps): string => props.theme.colors.toastBackground};
 	border-left-color: #2563eb;
 `;
 

--- a/src/utils/sheetHelpers.ts
+++ b/src/utils/sheetHelpers.ts
@@ -56,22 +56,16 @@ export const showEditPubkySheet = ({
 };
 
 export const showImportSuccessSheet = ({
-	modalTitle = i18n.t('import.pubkyImported'),
-	description,
 	isNewPubky = true,
 	pubky,
 	onContinue = (): void => {},
 }: {
-	modalTitle?: string;
-	description?: string;
 	isNewPubky?: boolean;
 	pubky: string;
 	onContinue?: () => void;
 }): void => {
 	SheetManager.show('import-success', {
 		payload: {
-			modalTitle,
-			description,
 			isNewPubky,
 			pubky,
 			onContinue,


### PR DESCRIPTION
### Description

Refreshes the pubky card and profile surfaces, consolidates shared card-gradient styling, and removes redundant presentation and payload plumbing across setup, import, authentication, and detail flows.

Closes https://github.com/pubky/pubky-ring/issues/288 https://github.com/pubky/pubky-ring/issues/273

### Changes

- Introduce a shared `CardGradient` theme surface and narrow theme tokens to card and toast needs, replacing several one-off styled wrapper components with native `View` or `Animated.View` usage.
- Rework `PubkyCard`, `PubkyBox`, and `PubkyProfile` around the shared gradient/card presentation, consistent avatar sizing, simplified derived text values, and translated labels.
- Replace `PubkyListHeader` with `PubkyDetailCard`, updating the detail flow and action layout while removing unused memoized primitive values and styles.
- Simplify `ImportSuccessSheet` and `showImportSuccessSheet` by removing unused title/description payload props and rendering the shared pubky profile presentation directly.
- Update authentication, delete, select, session, settings, about, and QR views to use the streamlined surfaces and remove redundant transparent/background styling.
- Refine avatar output with flush identicon padding and simpler public-key/radius derivation; select-pubky cards now expose a navigation chevron and hide the list scroll indicator.
