### PR TITLE
fix(ui): make keyboard respect theme

### DIFF
--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -20,7 +20,9 @@ export const View = styled.View<BackgroundColorProps>`
 	border-color: ${(props): string => props.theme.colors.textPrimary};
 `;
 
-const StyledTextInput = styled.TextInput<{ theme: Theme }>`
+const StyledTextInput = styled.TextInput.attrs<{ theme: Theme }>(props => ({
+	keyboardAppearance: props.theme.keyboardAppearance,
+}))`
 	color: ${(props): string => props.theme.colors.textSecondary};
 	font-family: ${fontFamily};
 	font-size: 17px;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,4 +1,7 @@
+import { TextInputProps } from 'react-native';
+
 export interface Theme {
+	keyboardAppearance: NonNullable<TextInputProps['keyboardAppearance']>;
 	colors: {
 		// Accent colors
 		pubkyRing: string;
@@ -31,6 +34,7 @@ export const accentColors = {
 };
 
 export const lightTheme: Theme = {
+	keyboardAppearance: 'light',
 	colors: {
 		...accentColors,
 		background: '#fff',
@@ -46,6 +50,7 @@ export const lightTheme: Theme = {
 };
 
 export const darkTheme: Theme = {
+	keyboardAppearance: 'dark',
 	colors: {
 		...accentColors,
 		background: '#000',


### PR DESCRIPTION
Make the software keyboard respect the current theme (light/dark), iOS only.

Related: https://github.com/pubky/pubky-ring/issues/234