### PR TITLE
test(unit): add unit tests for input parsing and routing

### DIFF
--- a/.github/workflows/unit-checks.yml
+++ b/.github/workflows/unit-checks.yml
@@ -1,14 +1,16 @@
-name: TypeScript Check
+name: Unit Checks
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
 jobs:
-  typecheck:
+  checks:
     runs-on: ubuntu-latest
     concurrency:
-      group: typecheck-${{ github.head_ref }}
+      group: unit-checks-${{ github.head_ref || github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -26,3 +28,6 @@ jobs:
 
     - name: Run TypeScript check
       run: yarn typecheck
+
+    - name: Run Jest tests
+      run: yarn test

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,14 +1,118 @@
-/**
- * @format
- */
-
 import 'react-native';
-import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import React, { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react-native';
+
+jest.mock('react-native-actions-sheet', () => {
+	const React = require('react');
+
+	return {
+		__esModule: true,
+		default: ({ children }: { children?: ReactNode }) => React.createElement(React.Fragment, null, children),
+		registerSheet: jest.fn(),
+		SheetProvider: ({ children }: { children?: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+	};
+});
+
+jest.mock('../src/navigation/RootNavigator.tsx', () => {
+	const React = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		default: () => React.createElement(View, { testID: 'RootNavigator' }),
+	};
+});
+
+const mockState = {
+	settings: {
+		theme: 'dark',
+		isOnline: true,
+	},
+};
+
+jest.mock('react-redux', () => ({
+	__esModule: true,
+	useDispatch: () => jest.fn(),
+	useSelector: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+	shallowEqual: jest.fn(),
+}));
+
+jest.mock('../src/store/selectors/settingsSelectors.ts', () => ({
+	__esModule: true,
+	getTheme: (state: typeof mockState) => state.settings.theme,
+	getIsOnline: (state: typeof mockState) => state.settings.isOnline,
+}));
+
+jest.mock('../src/store/slices/settingsSlice.ts', () => ({
+	__esModule: true,
+	updateIsOnline: (payload: unknown) => ({ type: 'settings/updateIsOnline', payload }),
+}));
+
+jest.mock('../src/store/slices/pubkysSlice.ts', () => ({
+	__esModule: true,
+	setDeepLink: (payload: unknown) => ({ type: 'pubky/setDeepLink', payload }),
+}));
+
+jest.mock('../src/utils/helpers.ts', () => ({
+	__esModule: true,
+	checkNetworkConnection: jest.fn(),
+	showToast: jest.fn(),
+}));
+
+jest.mock('../src/utils/inputParser.ts', () => ({
+	__esModule: true,
+	parseInput: jest.fn(async input => ({ rawInput: input })),
+}));
+
+jest.mock('@react-native-community/netinfo', () => ({
+	__esModule: true,
+	default: {
+		addEventListener: jest.fn(() => jest.fn()),
+	},
+}));
+
+jest.mock('react-native-toast-message', () => {
+	const React = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		default: () => React.createElement(View, { testID: 'Toast' }),
+	};
+});
+
+jest.mock('react-native-safe-area-context', () => {
+	const React = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		SafeAreaProvider: ({ children }: { children?: ReactNode }) =>
+			React.createElement(View, null, children),
+		SafeAreaView: ({ children }: { children?: ReactNode }) =>
+			React.createElement(View, null, children),
+		useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+		useSafeAreaFrame: () => ({ x: 0, y: 0, width: 320, height: 640 }),
+	};
+});
+
+jest.mock('../src/theme/toastConfig.tsx', () => ({
+	__esModule: true,
+	toastConfig: () => ({}),
+}));
+
+jest.mock('react-i18next', () => ({
+	__esModule: true,
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
 import App from '../App';
 
 test('renders correctly', async () => {
-	await ReactTestRenderer.act(() => {
-		ReactTestRenderer.create(<App />);
-	});
+	render(<App />);
+
+	expect(screen.getByTestId('RootNavigator')).toBeTruthy();
 });

--- a/__tests__/inputParser.test.ts
+++ b/__tests__/inputParser.test.ts
@@ -1,0 +1,204 @@
+import { InputAction, parseInput } from '../src/utils/inputParser';
+import { EBackupPreference } from '../src/types/pubky';
+import { ok, err } from '@synonymdev/result';
+import * as Pubky from '@synonymdev/react-native-pubky';
+
+jest.mock('@synonymdev/react-native-pubky', () => {
+	const { err } = require('@synonymdev/result');
+
+	return {
+		__esModule: true,
+		parseAuthUrl: jest.fn(async () => err('not an auth url')),
+		mnemonicPhraseToKeypair: jest.fn(async () => err('not a mnemonic')),
+		getPublicKeyFromSecretKey: jest.fn(async () => err('not a secret key')),
+	};
+});
+
+const parseAuthUrlMock = Pubky.parseAuthUrl as jest.MockedFunction<typeof Pubky.parseAuthUrl>;
+const mnemonicPhraseToKeypairMock = Pubky.mnemonicPhraseToKeypair as jest.MockedFunction<
+	typeof Pubky.mnemonicPhraseToKeypair
+>;
+const getPublicKeyFromSecretKeyMock = Pubky.getPublicKeyFromSecretKey as jest.MockedFunction<
+	typeof Pubky.getPublicKeyFromSecretKey
+>;
+
+describe('parseInput', () => {
+	beforeEach(() => {
+		parseAuthUrlMock.mockResolvedValue(err('not an auth url'));
+		mnemonicPhraseToKeypairMock.mockResolvedValue(err('not a mnemonic'));
+		getPublicKeyFromSecretKeyMock.mockResolvedValue(err('not a secret key'));
+	});
+
+	it('preserves nested x-callback URLs when parsing session deeplinks', async () => {
+		const xSuccess = 'bitkit://wallet/callback?nonce=abc123&state=ready';
+		const xError = 'bitkit://wallet/error?nonce=abc123&reason=denied';
+		const rawInput =
+			`pubkyring://session?x-success=${encodeURIComponent(xSuccess)}` +
+			`&x-error=${encodeURIComponent(xError)}` +
+			'&x-source=Bitkit';
+
+		const parsed = await parseInput(rawInput, 'deeplink');
+
+		expect(parsed.action).toBe(InputAction.Session);
+		expect(parsed.data).toEqual({
+			action: InputAction.Session,
+			params: {
+				xCallback: {
+					xSuccess,
+					xError,
+					xCancel: undefined,
+					xSource: 'Bitkit',
+				},
+			},
+		});
+	});
+
+	it('extracts invite codes from URLs without losing x-callback parameters', async () => {
+		const xSuccess = 'pubky://invite/accepted?token=abc&next=home';
+		const rawInput = `https://example.com/invite/ABCD-1234-WXYZ?x-success=${encodeURIComponent(xSuccess)}`;
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parsed.action).toBe(InputAction.Invite);
+		expect(parsed.data).toEqual({
+			action: InputAction.Invite,
+			params: {
+				inviteCode: 'ABCD-1234-WXYZ',
+				xCallback: {
+					xSuccess,
+					xError: undefined,
+					xCancel: undefined,
+					xSource: undefined,
+				},
+			},
+		});
+	});
+
+	it('parses standalone invite codes', async () => {
+		const parsed = await parseInput('ABCD-1234-WXYZ', 'clipboard');
+
+		expect(parsed).toMatchObject({
+			action: InputAction.Invite,
+			data: {
+				action: InputAction.Invite,
+				params: {
+					inviteCode: 'ABCD-1234-WXYZ',
+				},
+			},
+			source: 'clipboard',
+			rawInput: 'ABCD-1234-WXYZ',
+		});
+	});
+
+	it('parses migration deeplinks before stripping protocols', async () => {
+		const parsed = await parseInput('pubkyring://migrate/?index=2&total=5&key=pubky-key-2', 'scan');
+
+		expect(parsed).toEqual({
+			action: InputAction.Migrate,
+			data: {
+				action: InputAction.Migrate,
+				params: {
+					index: 2,
+					total: 5,
+					key: 'pubky-key-2',
+				},
+			},
+			source: 'scan',
+			rawInput: 'pubkyring://migrate/?index=2&total=5&key=pubky-key-2',
+		});
+	});
+
+	it('parses signup deeplinks with decoded fields, caps, and callbacks', async () => {
+		const xSuccess = 'bitkit://signup/success?nonce=abc&next=home';
+		const rawInput =
+			'pubkyring://signup?' +
+			`hs=${encodeURIComponent('https://homeserver.example.com')}` +
+			'&st=ABCD-1234-WXYZ' +
+			`&relay=${encodeURIComponent('wss://relay.example.com')}` +
+			'&secret=secret-value' +
+			'&caps=pubky.app:read,pubky.app:write' +
+			`&x-success=${encodeURIComponent(xSuccess)}` +
+			'&x-source=Bitkit';
+
+		const parsed = await parseInput(rawInput, 'deeplink');
+
+		expect(parsed.action).toBe(InputAction.Signup);
+		expect(parsed.data).toEqual({
+			action: InputAction.Signup,
+			params: {
+				homeserver: 'https://homeserver.example.com',
+				inviteCode: 'ABCD-1234-WXYZ',
+				relay: 'wss://relay.example.com',
+				secret: 'secret-value',
+				caps: ['pubky.app:read', 'pubky.app:write'],
+				xCallback: {
+					xSuccess,
+					xError: undefined,
+					xCancel: undefined,
+					xSource: 'Bitkit',
+				},
+			},
+		});
+	});
+
+	it('parses signin deeplinks through the Pubky auth parser', async () => {
+		parseAuthUrlMock.mockResolvedValue(
+			ok({
+				relay: 'wss://relay.example.com',
+				secret: 'auth-secret',
+				capabilities: [
+					{ path: '/pub/pubky.app/profile.json', permission: 'read' },
+					{ path: '/pub/pubky.app/session.json', permission: 'write' },
+				],
+			}),
+		);
+		const xCancel = 'bitkit://auth/cancel?nonce=abc&reason=user';
+		const rawInput =
+			'pubkyring://signin?' +
+			'caps=ignored-by-mock' +
+			'&secret=auth-secret' +
+			`&relay=${encodeURIComponent('wss://relay.example.com')}` +
+			`&x-cancel=${encodeURIComponent(xCancel)}`;
+
+		const parsed = await parseInput(rawInput, 'deeplink');
+
+		expect(parseAuthUrlMock).toHaveBeenCalledWith(expect.stringContaining('pubkyauth:///?'));
+		expect(parsed.action).toBe(InputAction.Auth);
+		expect(parsed.data).toEqual({
+			action: InputAction.Auth,
+			params: {
+				relay: 'wss://relay.example.com',
+				secret: 'auth-secret',
+				caps: ['/pub/pubky.app/profile.json:read', '/pub/pubky.app/session.json:write'],
+				xCallback: {
+					xSuccess: undefined,
+					xError: undefined,
+					xCancel,
+					xSource: undefined,
+				},
+			},
+			rawUrl: expect.stringContaining('pubkyauth:///?'),
+		});
+	});
+
+	it('normalizes valid recovery phrases for import', async () => {
+		mnemonicPhraseToKeypairMock.mockResolvedValue(
+			ok({ secret_key: 'secret-key', public_key: 'public-key', uri: 'pubky://public-key' }),
+		);
+
+		const parsed = await parseInput('one-two_three+four five six seven eight nine ten eleven twelve', 'clipboard');
+
+		expect(parsed).toEqual({
+			action: InputAction.Import,
+			data: {
+				action: InputAction.Import,
+				params: {
+					data: 'one two three four five six seven eight nine ten eleven twelve',
+					backupPreference: EBackupPreference.recoveryPhrase,
+				},
+			},
+			source: 'clipboard',
+			rawInput: 'one-two_three+four five six seven eight nine ten eleven twelve',
+		});
+	});
+});

--- a/__tests__/inputRouter.test.ts
+++ b/__tests__/inputRouter.test.ts
@@ -1,0 +1,292 @@
+import { ok, err } from '@synonymdev/result';
+import { EBackupPreference } from '../src/types/pubky';
+import {
+	actionRequiresNetwork,
+	actionRequiresPubky,
+	routeInput,
+	shouldCloseCameraBeforeRouting,
+} from '../src/utils/inputRouter';
+import { InputAction, ParsedInput } from '../src/utils/inputParser';
+import { handleAuthAction } from '../src/utils/actions/authAction';
+import { handleImportAction } from '../src/utils/actions/importAction';
+import { handleMigrateAction } from '../src/utils/actions/migrateAction';
+import { handleSignupAction } from '../src/utils/actions/signupAction';
+import { handleInviteAction } from '../src/utils/actions/inviteAction';
+import { handleSessionAction } from '../src/utils/actions/sessionAction';
+
+jest.mock('../src/i18n', () => ({
+	__esModule: true,
+	default: {
+		t: (key: string) => key,
+	},
+}));
+
+jest.mock('@synonymdev/react-native-pubky', () => ({
+	__esModule: true,
+	parseAuthUrl: jest.fn(),
+	mnemonicPhraseToKeypair: jest.fn(),
+	getPublicKeyFromSecretKey: jest.fn(),
+}));
+
+jest.mock('../src/utils/errorHandler', () => ({
+	__esModule: true,
+	getErrorMessage: (error: unknown, fallback: string) => {
+		if (error instanceof Error && error.message) return error.message;
+		if (typeof error === 'string' && error) return error;
+		return fallback;
+	},
+}));
+
+jest.mock('../src/utils/actions/authAction', () => ({
+	__esModule: true,
+	handleAuthAction: jest.fn(),
+}));
+
+jest.mock('../src/utils/actions/importAction', () => ({
+	__esModule: true,
+	handleImportAction: jest.fn(),
+}));
+
+jest.mock('../src/utils/actions/migrateAction', () => ({
+	__esModule: true,
+	handleMigrateAction: jest.fn(),
+}));
+
+jest.mock('../src/utils/actions/signupAction', () => ({
+	__esModule: true,
+	handleSignupAction: jest.fn(),
+}));
+
+jest.mock('../src/utils/actions/inviteAction', () => ({
+	__esModule: true,
+	handleInviteAction: jest.fn(),
+}));
+
+jest.mock('../src/utils/actions/sessionAction', () => ({
+	__esModule: true,
+	handleSessionAction: jest.fn(),
+}));
+
+const handleAuthActionMock = handleAuthAction as jest.MockedFunction<typeof handleAuthAction>;
+const handleImportActionMock = handleImportAction as jest.MockedFunction<typeof handleImportAction>;
+const handleMigrateActionMock = handleMigrateAction as jest.MockedFunction<typeof handleMigrateAction>;
+const handleSignupActionMock = handleSignupAction as jest.MockedFunction<typeof handleSignupAction>;
+const handleInviteActionMock = handleInviteAction as jest.MockedFunction<typeof handleInviteAction>;
+const handleSessionActionMock = handleSessionAction as jest.MockedFunction<typeof handleSessionAction>;
+
+const dispatch = jest.fn();
+
+const parsedInput = (data: ParsedInput['data'], source: ParsedInput['source'] = 'scan'): ParsedInput => ({
+	action: data.action,
+	data,
+	source,
+	rawInput: `${data.action}:raw`,
+});
+
+const resultErrorMessage = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+describe('routeInput', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it.each([
+		{
+			action: InputAction.Auth,
+			data: {
+				action: InputAction.Auth,
+				params: { relay: 'wss://relay.example.com', secret: 'secret', caps: ['pubky.app:read'] },
+				rawUrl: 'pubkyauth:///?secret=secret',
+			},
+			handler: handleAuthActionMock,
+			handlerValue: 'authorized',
+			expectedValue: {
+				success: true,
+				action: InputAction.Auth,
+				message: 'authorized',
+			},
+		},
+		{
+			action: InputAction.Import,
+			data: {
+				action: InputAction.Import,
+				params: {
+					data: 'one two three four five six seven eight nine ten eleven twelve',
+					backupPreference: EBackupPreference.recoveryPhrase,
+				},
+			},
+			handler: handleImportActionMock,
+			handlerValue: 'pubky-imported',
+			expectedValue: {
+				success: true,
+				action: InputAction.Import,
+				pubky: 'pubky-imported',
+				message: 'router.importSuccessful',
+			},
+		},
+		{
+			action: InputAction.Migrate,
+			data: {
+				action: InputAction.Migrate,
+				params: { index: 1, total: 3, key: 'key-1' },
+			},
+			handler: handleMigrateActionMock,
+			handlerValue: 'pubky-migrated',
+			expectedValue: {
+				success: true,
+				action: InputAction.Migrate,
+				pubky: 'pubky-migrated',
+				message: 'router.migrateSuccessful',
+			},
+		},
+		{
+			action: InputAction.Signup,
+			data: {
+				action: InputAction.Signup,
+				params: {
+					homeserver: 'https://homeserver.example.com',
+					inviteCode: 'ABCD-1234-WXYZ',
+					relay: 'wss://relay.example.com',
+					secret: 'secret',
+					caps: ['pubky.app:write'],
+				},
+			},
+			handler: handleSignupActionMock,
+			handlerValue: 'pubky-signed-up',
+			expectedValue: {
+				success: true,
+				action: InputAction.Signup,
+				pubky: 'pubky-signed-up',
+				message: 'router.signupSuccessful',
+			},
+		},
+		{
+			action: InputAction.Invite,
+			data: {
+				action: InputAction.Invite,
+				params: { inviteCode: 'ABCD-1234-WXYZ' },
+			},
+			handler: handleInviteActionMock,
+			handlerValue: 'pubky-invited',
+			expectedValue: {
+				success: true,
+				action: InputAction.Invite,
+				pubky: 'pubky-invited',
+				message: 'router.inviteProcessed',
+			},
+		},
+		{
+			action: InputAction.Session,
+			data: {
+				action: InputAction.Session,
+				params: { xCallback: { xSuccess: 'bitkit://session' } },
+			},
+			handler: handleSessionActionMock,
+			handlerValue: 'pubky-session',
+			expectedValue: {
+				success: true,
+				action: InputAction.Session,
+				pubky: 'pubky-session',
+				message: 'router.sessionReturned',
+			},
+		},
+	])('routes $action input to the matching handler', async ({ data, handler, handlerValue, expectedValue }) => {
+		handler.mockResolvedValue(ok(handlerValue));
+		const parsed = parsedInput(data as ParsedInput['data'], 'deeplink');
+
+		const result = await routeInput(parsed, { dispatch, pubky: 'pubky-selected' });
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) {
+			expect(result.value).toEqual(expectedValue);
+		}
+		expect(handler).toHaveBeenCalledWith(data, {
+			dispatch,
+			pubky: 'pubky-selected',
+			isDeeplink: true,
+		});
+	});
+
+	it('lets explicit context override the derived deeplink flag', async () => {
+		handleImportActionMock.mockResolvedValue(ok('pubky-imported'));
+		const parsed = parsedInput(
+			{
+				action: InputAction.Import,
+				params: {
+					data: 'secret-key',
+					backupPreference: EBackupPreference.encryptedFile,
+				},
+			},
+			'deeplink',
+		);
+
+		await routeInput(parsed, { dispatch, isDeeplink: false, skipImportSheet: true });
+
+		expect(handleImportActionMock).toHaveBeenCalledWith(parsed.data, {
+			dispatch,
+			isDeeplink: false,
+			skipImportSheet: true,
+		});
+	});
+
+	it('returns handler error messages without wrapping useful errors', async () => {
+		handleInviteActionMock.mockResolvedValue(err(new Error('Invite code was already used')));
+		const parsed = parsedInput({
+			action: InputAction.Invite,
+			params: { inviteCode: 'ABCD-1234-WXYZ' },
+		});
+
+		const result = await routeInput(parsed, { dispatch });
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(resultErrorMessage(result.error)).toBe('Invite code was already used');
+		}
+	});
+
+	it('rejects unknown input without calling action handlers', async () => {
+		const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+		const parsed = parsedInput({
+			action: InputAction.Unknown,
+			params: { rawData: 'not parseable' },
+		});
+
+		const result = await routeInput(parsed, { dispatch });
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(resultErrorMessage(result.error)).toBe('errors.unrecognizedFormat');
+		}
+		expect(handleAuthActionMock).not.toHaveBeenCalled();
+		expect(handleImportActionMock).not.toHaveBeenCalled();
+		expect(handleMigrateActionMock).not.toHaveBeenCalled();
+		expect(handleSignupActionMock).not.toHaveBeenCalled();
+		expect(handleInviteActionMock).not.toHaveBeenCalled();
+		expect(handleSessionActionMock).not.toHaveBeenCalled();
+
+		logSpy.mockRestore();
+	});
+});
+
+describe('input routing helpers', () => {
+	it('identifies actions that need selected pubky context', () => {
+		expect(actionRequiresPubky(InputAction.Auth)).toBe(true);
+		expect(actionRequiresPubky(InputAction.Session)).toBe(true);
+		expect(actionRequiresPubky(InputAction.Import)).toBe(false);
+	});
+
+	it('identifies actions that need network access', () => {
+		expect(actionRequiresNetwork(InputAction.Auth)).toBe(true);
+		expect(actionRequiresNetwork(InputAction.Signup)).toBe(true);
+		expect(actionRequiresNetwork(InputAction.Invite)).toBe(true);
+		expect(actionRequiresNetwork(InputAction.Session)).toBe(true);
+		expect(actionRequiresNetwork(InputAction.Import)).toBe(false);
+		expect(actionRequiresNetwork(InputAction.Migrate)).toBe(false);
+	});
+
+	it('keeps the camera open only for migration frames', () => {
+		expect(shouldCloseCameraBeforeRouting(InputAction.Migrate)).toBe(false);
+		expect(shouldCloseCameraBeforeRouting(InputAction.Invite)).toBe(true);
+	});
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
   preset: '@react-native/jest-preset',
+  setupFiles: ['react-native-gesture-handler/jestSetup'],
+  watchman: false,
 };

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@react-native/metro-config": "0.85.2",
     "@react-native/typescript-config": "0.85.2",
     "@svgr/cli": "^8.1.0",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.2.0",
     "@types/react-test-renderer": "^19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,6 +1317,11 @@
   dependencies:
     "@jest/types" "^29.6.3"
 
+"@jest/diff-sequences@30.4.0":
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz#8be2d260e6241d6cddddd102c304fe13b4fc8e3e"
+  integrity sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==
+
 "@jest/environment@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
@@ -1353,6 +1358,11 @@
     jest-message-util "^29.7.0"
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
+
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
 
 "@jest/globals@^29.7.0":
   version "29.7.0"
@@ -1393,6 +1403,13 @@
     string-length "^4.0.1"
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-30.4.1.tgz#c3703fdd71357e2c83aa59bd38469e60a11529c6"
+  integrity sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
 
 "@jest/schemas@^29.6.3":
   version "29.6.3"
@@ -2040,6 +2057,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
   integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.49"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.49.tgz#4f1369234f2ecf693866476c3b2e1b54d2a9d68e"
+  integrity sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==
+
 "@sinonjs/commons@^3.0.0":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
@@ -2191,6 +2213,16 @@
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@synonymdev/result/-/result-0.0.2.tgz#c526743e4f1d3ec1d24a1952281b5daa77ba3fbc"
   integrity sha512-Ni5qknulcf350qfPVTw3DWXqT2i6K68BoFc18zlqIAj9YA2RUOIJsKTdemX31i3wSma5LRHVcGLESVga16iAag==
+
+"@testing-library/react-native@^13.3.3":
+  version "13.3.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-13.3.3.tgz#4bf02911c4e18075df40b5de0e029c209fb45bda"
+  integrity sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==
+  dependencies:
+    jest-matcher-utils "^30.0.5"
+    picocolors "^1.1.1"
+    pretty-format "^30.0.5"
+    redent "^3.0.0"
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -2538,7 +2570,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
@@ -4577,6 +4609,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -5024,6 +5061,16 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
+jest-diff@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.4.1.tgz#26691c73975768409af4a66b2754cea3182aa2dc"
+  integrity sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==
+  dependencies:
+    "@jest/diff-sequences" "30.4.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.4.1"
+
 jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
@@ -5105,6 +5152,16 @@ jest-matcher-utils@^29.7.0:
     jest-diff "^29.7.0"
     jest-get-type "^29.6.3"
     pretty-format "^29.7.0"
+
+jest-matcher-utils@^30.0.5:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz#3fee8c89dbd8fc6e60eb590def9897e18f110ec4"
+  integrity sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.4.1"
+    pretty-format "30.4.1"
 
 jest-message-util@^29.7.0:
   version "29.7.0"
@@ -5853,6 +5910,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
 minimatch@^10.2.2:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
@@ -6301,6 +6363,16 @@ prettier@^2.8.7:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
+pretty-format@30.4.1, pretty-format@^30.0.5:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.4.1.tgz#0911652e92e1e91f475e3e6a16e628e50649ea69"
+  integrity sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==
+  dependencies:
+    "@jest/schemas" "30.4.1"
+    ansi-styles "^5.2.0"
+    react-is-18 "npm:react-is@^18.3.1"
+    react-is-19 "npm:react-is@^19.2.5"
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -6427,6 +6499,16 @@ react-i18next@^16.3.5:
     html-parse-stringify "^3.0.1"
     use-sync-external-store "^1.6.0"
 
+"react-is-18@npm:react-is@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+"react-is-19@npm:react-is@^19.2.5":
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.6.tgz#aeee6159b159eb7f520d672cffcc69e7052d288f"
+  integrity sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -6437,10 +6519,15 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-is@^19.1.0, react-is@^19.2.3:
+react-is@^19.1.0:
   version "19.2.5"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.5.tgz#7e7b54143e9313fed787b23fd4295d5a23872ad9"
   integrity sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==
+
+react-is@^19.2.3:
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.6.tgz#aeee6159b159eb7f520d672cffcc69e7052d288f"
+  integrity sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==
 
 react-native-actions-sheet@^10.1.2:
   version "10.1.2"
@@ -6693,6 +6780,14 @@ readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 redux-logger@^3.0.6:
   version "3.0.6"
@@ -7363,6 +7458,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
### Description

Adds a Jest test layer for core input handling and wires it into CI

### Changes

- Replace the deprecated direct `react-test-renderer` App smoke test usage with `@testing-library/react-native`.
- Add parser coverage for invite codes/links, session callbacks, signup/signin deeplinks, migration QR links, and recovery phrase normalization.
- Add router coverage to verify parsed inputs dispatch to the correct action handlers and preserve routing context.
- Rename the TypeScript-only workflow to `unit-checks.yml` and run both `yarn typecheck` and `yarn test`.

### Verification

- `yarn test`
- `yarn typecheck`
