### PR TITLE
chore: bump version to 0.0.29

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,8 +82,8 @@ android {
         applicationId "to.pubky.ring"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 20
-        versionName "1.14"
+        versionCode 22
+        versionName "1.15"
     }
 
     signingConfigs {

--- a/ios/pubkyring.xcodeproj/project.pbxproj
+++ b/ios/pubkyring.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = KYH47R284B;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = pubkyring/Info.plist;
@@ -282,7 +282,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.14;
+				MARKETING_VERSION = 0.15;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -302,7 +302,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = KYH47R284B;
 				INFOPLIST_FILE = pubkyring/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Pubky Ring";
@@ -312,7 +312,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.14;
+				MARKETING_VERSION = 0.15;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubkyring",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "private": false,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This PR:
- Bumps the version to `0.0.29` in `package.json`
- Bumps to version to `1.15(22)` for Android
- Bumps the version to `0.15(2)` for iOS