### PR TITLE
feat: add QR scanner gallery picker and permission state

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1481,6 +1481,28 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - react-native-image-picker (8.2.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - react-native-netinfo (12.0.1):
     - hermes-engine
     - RCTRequired
@@ -2157,6 +2179,29 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - RNQrGenerator (2.0.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+    - ZXingObjC
   - RNReanimated (4.3.0):
     - hermes-engine
     - RCTRequired
@@ -2417,6 +2462,9 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - Yoga (0.0.0)
+  - ZXingObjC (3.6.9):
+    - ZXingObjC/All (= 3.6.9)
+  - ZXingObjC/All (3.6.9)
 
 DEPENDENCIES:
   - "AsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
@@ -2465,6 +2513,7 @@ DEPENDENCIES:
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
   - "react-native-device-brightness (from `../node_modules/@adrianso/react-native-device-brightness`)"
   - "react-native-document-picker (from `../node_modules/@react-native-documents/picker`)"
+  - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - "react-native-pubky (from `../node_modules/@synonymdev/react-native-pubky`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -2510,6 +2559,7 @@ DEPENDENCIES:
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
+  - RNQrGenerator (from `../node_modules/rn-qr-generator`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNShare (from `../node_modules/react-native-share`)
@@ -2520,6 +2570,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - MMKVCore
+    - ZXingObjC
 
 EXTERNAL SOURCES:
   AsyncStorage:
@@ -2613,6 +2664,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@adrianso/react-native-device-brightness"
   react-native-document-picker:
     :path: "../node_modules/@react-native-documents/picker"
+  react-native-image-picker:
+    :path: "../node_modules/react-native-image-picker"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-pubky:
@@ -2703,6 +2756,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-localize"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
+  RNQrGenerator:
+    :path: "../node_modules/rn-qr-generator"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -2763,6 +2818,7 @@ SPEC CHECKSUMS:
   react-native-blur: ea6c78ddeaa7aa0fce36ea29d1f81dd23063032a
   react-native-device-brightness: 1a997350d060c3df9f303b1df84a4f7c5cbeb924
   react-native-document-picker: 15cca2d1a6bfb6d0d3ff0283bd9b903e57cb028b
+  react-native-image-picker: 23540feacc79c63c60857f318fdfa8477c26e70a
   react-native-netinfo: 2f906d5d9a639090ed1c079135d6485a95f749f1
   react-native-pubky: 00b58b546df1d7dd45dbb0b1a1d91d82836b32c0
   react-native-safe-area-context: 6b4966397ada0f7dd481e4486a2ef936834861a1
@@ -2808,12 +2864,14 @@ SPEC CHECKSUMS:
   RNKeychain: 6778b35b5bd067c322f8479526ac09b1d61f31d0
   RNLocalize: f370284ea42c48f29f0d8dd3a7bcc28a04f82155
   RNPermissions: efe8a25c61593f06e89868940d9c08b21e0d6001
+  RNQrGenerator: c8b09365c7912af4184481b182af205f51c4897f
   RNReanimated: c4e6659e58b793885ae6da476cb514fc913e7b85
   RNScreens: 01b065ded2dfe7987bcce770ff3a196be417ff41
   RNShare: 7344a3a7d4e5df58c356ad0f79e4a3ef1325c635
   RNSVG: 04044c3abcf177fd674a1a3d13097efa1adebcbe
   RNWorklets: 4931990f73bc8f347586918b2e13f11dfadf3b75
   Yoga: 04bb4bfeb02c0000b940c1e6e89e856cd8de5a71
+  ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: f4a63f96e757c2de0d8f9bab4bdb629d23afd5ac
 

--- a/ios/pubkyring/PrivacyInfo.xcprivacy
+++ b/ios/pubkyring/PrivacyInfo.xcprivacy
@@ -11,6 +11,7 @@
 			<array>
 				<string>C617.1</string>
 				<string>0A2A.1</string>
+				<string>3B52.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-native-camera-kit": "18.0.0",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-gesture-handler": "^2.31.2",
+    "react-native-image-picker": "^8.2.1",
     "react-native-keychain": "^10.0.0",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-localize": "^3.7.0",
@@ -63,6 +64,7 @@
     "react-native-worklets": "^0.8.2",
     "react-redux": "^9.2.0",
     "redux-persist": "^6.0.0",
+    "rn-qr-generator": "^2.0.0",
     "styled-components": "^6.1.19"
   },
   "devDependencies": {

--- a/src/components/Camera/Camera.tsx
+++ b/src/components/Camera/Camera.tsx
@@ -1,16 +1,17 @@
-import React, { ReactElement, useState, useEffect, memo, useCallback } from 'react';
+import React, { ReactElement, ReactNode, useState, useEffect, memo, useCallback } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Camera as CameraKit, CameraType } from 'react-native-camera-kit';
 import CameraNoAuth from './CameraNoAuth';
 import { requestCameraPermission } from '../../utils/permissions';
 
 interface CameraProps {
-	children?: ReactElement;
+	children?: ReactNode;
 	bottomSheet?: boolean;
+	torchMode?: boolean;
 	onBarCodeRead: (data: string) => void;
 }
 
-const Camera = ({ children, onBarCodeRead }: CameraProps): ReactElement => {
+const Camera = ({ children, torchMode = false, onBarCodeRead }: CameraProps): ReactElement => {
 	const prevDataRef = React.useRef<string>('');
 
 	const [cameraState, setCameraState] = useState<{
@@ -90,6 +91,7 @@ const Camera = ({ children, onBarCodeRead }: CameraProps): ReactElement => {
 						showFrame={false}
 						onReadCode={handleCodeRead}
 						cameraType={CameraType.Back}
+						torchMode={torchMode ? 'on' : 'off'}
 						resizeMode="cover"
 					/>
 				</View>

--- a/src/components/Camera/CameraNoAuth.tsx
+++ b/src/components/Camera/CameraNoAuth.tsx
@@ -1,7 +1,69 @@
 import React, { ReactElement } from 'react';
-import { View } from '../../theme/components.ts';
+import { Linking, Platform, StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import Button from '../Button.tsx';
+import { Gear, Lock } from '../../icons/index.ts';
+import { BodyMBText, BodySText } from '../../theme/typography.ts';
+import { showToast } from '../../utils/helpers.ts';
 
 const CameraNoAuth = (): ReactElement => {
-	return <View />;
+	const { t } = useTranslation();
+
+	const handleOpenSettings = async (): Promise<void> => {
+		Platform.OS === 'ios'
+			? Linking.openURL('App-Prefs:Settings')
+			: Linking.sendIntent('android.settings.SETTINGS');
+	};
+
+	return (
+		<View style={styles.container}>
+			<View style={styles.iconContainer}>
+				<Lock size={32} />
+			</View>
+
+			<View style={styles.textContainer}>
+				<BodyMBText style={styles.title}>{t('permissions.cameraDeniedTitle')}</BodyMBText>
+				<BodySText style={styles.description}>{t('permissions.cameraDeniedMessage')}</BodySText>
+			</View>
+
+			<Button
+				text={t('permissions.openSettings')}
+				size="medium"
+				icon={<Gear />}
+				onPress={handleOpenSettings}
+			/>
+		</View>
+	);
 };
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: 24,
+		backgroundColor: 'rgba(255, 255, 255, 0.04)',
+		borderRadius: 16,
+	},
+	iconContainer: {
+		alignItems: 'center',
+		justifyContent: 'center',
+		width: 72,
+		height: 72,
+		borderRadius: '50%',
+		backgroundColor: 'rgba(255, 255, 255, 0.10)',
+	},
+	textContainer: {
+		marginTop: 12,
+		marginBottom: 24,
+		gap: 8,
+	},
+	title: {
+		textAlign: 'center',
+	},
+	description: {
+		textAlign: 'center',
+	},
+});
+
 export default CameraNoAuth;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import type { PressableProps, StyleProp, ViewStyle } from 'react-native';
+
+type IconButtonProps = {
+	icon: React.ReactNode;
+	size?: number;
+	active?: boolean;
+	disabled?: PressableProps['disabled'];
+	style?: StyleProp<ViewStyle>;
+	testID?: PressableProps['testID'];
+	onPress?: PressableProps['onPress'];
+};
+
+const IconButton = ({
+	active = false,
+	disabled = false,
+	icon,
+	style,
+	testID,
+	onPress,
+}: IconButtonProps): ReactElement => (
+	<Pressable
+		disabled={disabled}
+		style={({ pressed }) => [
+			styles.root,
+			active && styles.active,
+			disabled && styles.disabled,
+			pressed && styles.pressed,
+			style,
+		]}
+		testID={testID}
+		onPress={onPress}
+	>
+		{icon}
+	</Pressable>
+);
+
+const styles = StyleSheet.create({
+	root: {
+		alignItems: 'center',
+		justifyContent: 'center',
+		width: 48,
+		height: 48,
+		borderRadius: '50%',
+		backgroundColor: 'rgba(255, 255, 255, 0.16)',
+	},
+	active: {
+		backgroundColor: 'rgba(255, 255, 255, 0.32)',
+	},
+	pressed: {
+		backgroundColor: 'rgba(255, 255, 255, 0.32)',
+	},
+	disabled: {
+		opacity: 0.32,
+	},
+});
+
+export default IconButton;

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -1,15 +1,19 @@
-import React, { memo, ReactElement } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { memo, ReactElement, useCallback, useState } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { launchImageLibrary } from 'react-native-image-picker';
+import RNQRGenerator from 'rn-qr-generator';
 import MigrationProgressOverlay from './MigrationProgressOverlay';
 import Button from './Button.tsx';
 import Sheet from './Sheet.tsx';
 import Camera from './Camera/Camera.tsx';
 import { useTranslation } from 'react-i18next';
-import { Qrcode } from '../icons/index.ts';
+import { Flashlight, Image as ImageIcon, Qrcode } from '../icons/index.ts';
+import IconButton from './IconButton.tsx';
+import { showToast } from '../utils/helpers.ts';
 
 interface QRScannerProps {
 	title?: string;
-	onScan: (data: string) => void;
+	onScan: (data: string) => Promise<void> | void;
 	onCopyClipboard: () => Promise<void>;
 	onClose?: () => void;
 }
@@ -17,11 +21,93 @@ interface QRScannerProps {
 const QRScanner = ({ payload }: { payload: QRScannerProps }): ReactElement => {
 	const { t } = useTranslation();
 	const { onScan, onCopyClipboard, onClose, title = t('auth.authorize') } = payload;
+	const [torchMode, setTorchMode] = useState(false);
+	const [isProcessingImage, setIsProcessingImage] = useState(false);
+
+	const handlePickImage = useCallback(async (): Promise<void> => {
+		if (isProcessingImage) {
+			return;
+		}
+
+		setIsProcessingImage(true);
+
+		try {
+			const result = await launchImageLibrary({
+				mediaType: 'photo',
+				selectionLimit: 1,
+				includeBase64: false,
+			});
+
+			if (result.didCancel) {
+				setIsProcessingImage(false);
+				return;
+			}
+
+			if (result.errorCode) {
+				console.error('Failed to pick QR image:', result.errorMessage ?? result.errorCode);
+				showToast({
+					type: 'error',
+					title: t('common.error'),
+					description: t('scanner.imagePickerError'),
+				});
+				setIsProcessingImage(false);
+				return;
+			}
+
+			const image = result.assets?.[0];
+			if (!image?.uri) {
+				showToast({
+					type: 'error',
+					title: t('common.error'),
+					description: t('scanner.imagePickerError'),
+				});
+				setIsProcessingImage(false);
+				return;
+			}
+
+			const { values } = await RNQRGenerator.detect({
+				uri: image.uri,
+			});
+			if (!values.length) {
+				showToast({
+					type: 'error',
+					title: t('common.error'),
+					description: t('scanner.noQrFound'),
+				});
+				setIsProcessingImage(false);
+				return;
+			}
+
+			setIsProcessingImage(false);
+			await onScan(values[0]);
+		} catch (error) {
+			setIsProcessingImage(false);
+			console.error('Failed to pick QR image:', error);
+			showToast({
+				type: 'error',
+				title: t('common.error'),
+				description: t('scanner.imageDecodeError'),
+			});
+		}
+	}, [isProcessingImage, onScan, t]);
+
+	const handleToggleTorch = useCallback((): void => {
+		setTorchMode(prevTorchMode => !prevTorchMode);
+	}, []);
 
 	return (
 		<Sheet id="camera" title={title} onClose={onClose}>
 			<View style={styles.cameraContainer}>
-				<Camera onBarCodeRead={onScan} />
+				<Camera torchMode={torchMode} onBarCodeRead={onScan}>
+					<View style={styles.actionsRow}>
+						<IconButton
+							disabled={isProcessingImage}
+							icon={isProcessingImage ? <ActivityIndicator color="#ffffff" /> : <ImageIcon />}
+							onPress={handlePickImage}
+						/>
+						<IconButton active={torchMode} icon={<Flashlight />} onPress={handleToggleTorch} />
+					</View>
+				</Camera>
 				<MigrationProgressOverlay />
 			</View>
 			<View style={styles.buttonContainer}>
@@ -39,6 +125,15 @@ const QRScanner = ({ payload }: { payload: QRScannerProps }): ReactElement => {
 const styles = StyleSheet.create({
 	cameraContainer: {
 		flex: 1,
+	},
+	actionsRow: {
+		position: 'absolute',
+		top: 16,
+		left: 16,
+		right: 16,
+		zIndex: 2,
+		flexDirection: 'row',
+		justifyContent: 'space-between',
 	},
 	buttonContainer: {
 		flexDirection: 'row',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,6 +28,11 @@
 		"addPubky": "Add pubky",
 		"scanQR": "Scan QR"
 	},
+	"scanner": {
+		"imageDecodeError": "Unable to read this image.",
+		"imagePickerError": "Unable to open this image.",
+		"noQrFound": "No QR code was found in this image."
+	},
 	"settings": {
 		"title": "Settings",
 		"navigationAnimation": "Navigation Animation",
@@ -324,7 +329,10 @@
 	},
 	"permissions": {
 		"cameraTitle": "Permission to use camera",
-		"cameraMessage": "Pubky Ring needs permission to use your camera"
+		"cameraMessage": "Pubky Ring needs permission to use your camera",
+		"cameraDeniedTitle": "Camera access is off",
+		"cameraDeniedMessage": "Enable camera access in your device settings to scan QR codes.",
+		"openSettings": "Open Settings"
 	},
 	"keychain": {
 		"failedToGetValue": "Failed to get keychain value",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -28,6 +28,11 @@
 		"addPubky": "Añadir pubky",
 		"scanQR": "Escanear QR"
 	},
+	"scanner": {
+		"imageDecodeError": "No se puede leer esta imagen.",
+		"imagePickerError": "No se puede abrir esta imagen.",
+		"noQrFound": "No se encontró ningún código QR en esta imagen."
+	},
 	"settings": {
 		"title": "Ajustes",
 		"navigationAnimation": "Animación de la navegación",
@@ -325,7 +330,10 @@
 	},
 	"permissions": {
 		"cameraTitle": "Permiso para utilizar la cámara",
-		"cameraMessage": "Pubky Ring necesita permiso para usar su cámara"
+		"cameraMessage": "Pubky Ring necesita permiso para usar su cámara",
+		"cameraDeniedTitle": "El acceso a la cámara está desactivado",
+		"cameraDeniedMessage": "Active el acceso a la cámara en los ajustes del dispositivo para escanear códigos QR.",
+		"openSettings": "Abrir ajustes"
 	},
 	"keychain": {
 		"failedToGetValue": "Fallo al obtener el valor del llavero",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9336,6 +9336,11 @@ react-native-gesture-handler@^2.31.2:
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
 
+react-native-image-picker@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-image-picker/-/react-native-image-picker-8.2.1.tgz#1ac7826563cbaa5d5298d9f2acc53c69805e5393"
+  integrity sha512-FBeGYJGFDjMdGCcyubDJgBAPCQ4L1D3hwLXyUU91jY9ahOZMTbluceVvRmrEKqnDPFJ0gF1NVhJ0nr1nROFLdg==
+
 react-native-is-edge-to-edge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz#feb9a6a8faf0874298947edd556e5af22044e139"
@@ -9847,6 +9852,11 @@ rimraf@~2.4.0:
   integrity sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==
   dependencies:
     glob "^6.0.1"
+
+rn-qr-generator@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rn-qr-generator/-/rn-qr-generator-2.0.0.tgz#96c1c845f55c9ca474bb9e72d3370df9d0b2fa22"
+  integrity sha512-iaJp/EfAd2f8YHDDN6UwXS+WLPpIsGTtAGMIR36u+IxT4xOFsVVowfM1Bvfh3YsGvn+eV8vx6Fm2MIC/PT6Mtg==
 
 router@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
### Description

Adds photo picker and torch buttons to scanner, plus a clearer camera permission denied state that links users to OS settings.

### Changes

- Add torch and photo picker buttons at the top of the QR scanner camera view.
- Allow users to choose a photo from the system gallery and decode QR codes from the selected image.
- Add a reusable circular `IconButton` for scanner overlay actions.
- Replace the blank camera denied state with a localized permission message and an "Open Settings" button.
- Add `react-native-image-picker` and `rn-qr-generator`

<img width="350" alt="Simulator Screenshot - iPhone 17 - 2026-06-02 at 16 53 49" src="https://github.com/user-attachments/assets/c6e3d2b4-4346-4842-9dc0-e30f50efc9d6" />

https://github.com/user-attachments/assets/47eb1882-04e7-44bb-9b25-6a0d3bec23c0
