### PR TITLE
perf: apply React Native performance best practices

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,6 +78,13 @@ android {
     compileSdk rootProject.ext.compileSdkVersion
 
     namespace "to.pubkyring"
+
+    // Keep the Hermes bytecode bundle uncompressed so it can be memory-mapped
+    // (mmap) at startup instead of decompressed into memory, improving TTI.
+    androidResources {
+        noCompress += ['bundle']
+    }
+
     defaultConfig {
         applicationId "to.pubky.ring"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,9 @@
 module.exports = {
 	presets: ['module:@react-native/babel-preset'],
 	plugins: [
+		// React Compiler must run first so it can analyze components before
+		// other transforms. react-native-worklets/plugin must remain last.
+		'babel-plugin-react-compiler',
 		'react-native-worklets/plugin',
 	],
 };

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@wdio/mocha-framework": "^9.19.1",
     "@wdio/spec-reporter": "^9.19.1",
     "appium": "^2.19.0",
+    "babel-plugin-react-compiler": "^1.0.0",
     "chai": "5.1.2",
     "eslint": "9.26.0",
     "jest": "^29.6.3",

--- a/src/components/SelectPubky.tsx
+++ b/src/components/SelectPubky.tsx
@@ -17,6 +17,20 @@ import { BodyMText } from '../theme/typography.ts';
 type PubkyItem = { key: string; value: Pubky };
 const ROUTE_AFTER_CLOSE_DELAY = 100;
 
+const PubkyRow = memo(
+	({
+		item,
+		onPress,
+	}: {
+		item: PubkyItem;
+		onPress: (key: string) => void;
+	}): ReactElement => (
+		<TouchableOpacity style={styles.card} onPress={() => onPress(item.key)}>
+			<PubkyCard publicKey={item.key} name={item.value.name} showChevron={true} />
+		</TouchableOpacity>
+	),
+);
+
 const SelectPubky = ({
 	payload: { deepLink },
 }: {
@@ -64,19 +78,24 @@ const SelectPubky = ({
 		return pubkyArray.length > 0 ? t('pubky.selectPubkyMessage') : t('pubky.noPubkysAvailable');
 	}, [pubkyArray.length, t]);
 
+	const renderItem = useCallback(
+		(info: { item: PubkyItem }): ReactElement => (
+			<PubkyRow item={info.item} onPress={onPubkyPress} />
+		),
+		[onPubkyPress],
+	);
+
+	const keyExtractor = useCallback((item: PubkyItem): string => item.key, []);
+
 	return (
 		<Sheet id="select-pubky" title={t('pubky.selectPubky')} onClose={clearDeepLink}>
 			<BodyMText>{message}</BodyMText>
 			<View style={styles.listContainer}>
 				<FlashList<PubkyItem>
 					data={pubkyArray}
-					renderItem={({ item }) => (
-						<TouchableOpacity style={styles.card} onPress={() => onPubkyPress(item.key)}>
-							<PubkyCard publicKey={item.key} name={item.value.name} showChevron={true} />
-						</TouchableOpacity>
-					)}
+					renderItem={renderItem}
 					renderScrollComponent={ActionSheetScrollView}
-					keyExtractor={item => item.key}
+					keyExtractor={keyExtractor}
 					showsVerticalScrollIndicator={false}
 				/>
 			</View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,10 +326,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
@@ -1218,6 +1228,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.26.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -3864,6 +3882,13 @@ babel-plugin-polyfill-regenerator@^0.6.5, babel-plugin-polyfill-regenerator@^0.6
   integrity sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.8"
+
+babel-plugin-react-compiler@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz#bdf7360a23a4d5ebfca090255da3893efd07425f"
+  integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
+  dependencies:
+    "@babel/types" "^7.26.0"
 
 babel-plugin-syntax-hermes-parser@0.33.3:
   version "0.33.3"


### PR DESCRIPTION
Ran Pubky Ring against [react-native-best-practices](https://github.com/callstackincubator/agent-skills/tree/main/skills/react-native-best-practices) which resulted in the following:
- Enable React Compiler (babel-plugin-react-compiler) for automatic memoization
- Stabilize SelectPubky FlashList renderItem/keyExtractor and memoize row
 - Disable Hermes bytecode bundle compression on Android for mmap (faster TTI)