### PR TITLE
fix: update copy across the app

### DIFF
--- a/src/components/AddPubky.tsx
+++ b/src/components/AddPubky.tsx
@@ -201,13 +201,13 @@ const AddPubky = ({
 				return [
 					{
 						id: 'EncryptedFileButton',
-						text: i18n.t('backup.encryptedFile'),
+						text: i18n.t('addPubky.encryptedFile'),
 						icon: <Lock />,
 						onPress: onUploadFile,
 					},
 					{
 						id: 'RecoveryPhraseButton',
-						text: i18n.t('backup.recoveryPhrase'),
+						text: i18n.t('addPubky.recoveryPhrase'),
 						icon: <FileText />,
 						onPress: onMnemonicPhrase,
 					},

--- a/src/components/BackupPrompt.tsx
+++ b/src/components/BackupPrompt.tsx
@@ -1,5 +1,6 @@
 import React, { memo, ReactElement, useCallback, useMemo, useState } from 'react';
 import { Keyboard, StyleSheet, View } from 'react-native';
+import { Trans, useTranslation } from 'react-i18next';
 import { SheetManager } from 'react-native-actions-sheet';
 import { TextInput, TouchableOpacity } from '../theme/components.ts';
 import Button from '../components/Button.tsx';
@@ -8,7 +9,6 @@ import { Result } from '@synonymdev/result';
 import { EBackupPreference } from '../types/pubky.ts';
 import { usePubkyManagement } from '../hooks/usePubkyManagement.ts';
 import { BACKUP_PASSWORD_CHAR_MIN } from '../utils/constants.ts';
-import { useTranslation } from 'react-i18next';
 import { BodyMText, BodyMSBText, BodySText, CaptionBText, CaptionText } from '../theme/typography';
 import Sheet from './Sheet.tsx';
 import { EBackupPromptViewId } from '../utils/sheetHelpers.ts';
@@ -85,7 +85,7 @@ const BackupPrompt = ({
 	const title = useMemo(() => {
 		switch (viewId) {
 			case EBackupPromptViewId.backup:
-				return t('backup.encryptedFile');
+				return t('backup.file.navTitle');
 			case EBackupPromptViewId.import:
 				return t('import.title');
 			default:
@@ -120,8 +120,12 @@ const BackupPrompt = ({
 			case EBackupPromptViewId.backup:
 				return (
 					<CaptionText style={styles.inputLabel} numberOfLines={1} ellipsizeMode="middle">
-						{t('backup.passphraseFor')}
-						<CaptionBText>{truncatedPubky}</CaptionBText>
+						<Trans
+							t={t}
+							i18nKey="backup.passphraseFor"
+							components={{ accent: <CaptionBText colorName="textPrimary" /> }}
+							values={{ pubky: truncatedPubky }}
+						/>
 					</CaptionText>
 				);
 			case EBackupPromptViewId.import:

--- a/src/components/PubkySetup/NewHomeserverSetup.tsx
+++ b/src/components/PubkySetup/NewHomeserverSetup.tsx
@@ -1,15 +1,15 @@
 import React, { memo, ReactElement, useCallback, useMemo, useState } from 'react';
 import { StyleSheet, Image, Platform, View } from 'react-native';
-import { useTranslation } from 'react-i18next';
-import { TouchableOpacity } from '../../theme/components.ts';
+import { Trans, useTranslation } from 'react-i18next';
 import { SheetManager } from 'react-native-actions-sheet';
+import { TouchableOpacity } from '../../theme/components.ts';
 import { showEditPubkySheet } from '../../utils/sheetHelpers.ts';
 import { defaultPubkyState } from '../../store/shapes/pubky.ts';
 import {
+	BodyMBText,
 	BodyMText,
 	BodySSBText,
 	BodySSpacedText,
-	BoldText,
 	CaptionText,
 	DisplayText,
 } from '../../theme/typography';
@@ -72,8 +72,14 @@ const NewHomeserverSetup = ({
 	return (
 		<>
 			<DisplayText style={styles.headerText}>{t('homeserver.dataHosting')}</DisplayText>
+
 			<BodyMText style={styles.message}>
-				{t('homeserver.chooseMessage')} <BoldText>{truncatedPubky}</BoldText>
+				<Trans
+					t={t}
+					i18nKey="homeserver.message"
+					components={{ accent: <BodyMBText colorName="textPrimary" /> }}
+					values={{ pubky: truncatedPubky }}
+				/>
 			</BodyMText>
 
 			<View style={styles.optionsContainer}>

--- a/src/components/PubkySetup/Welcome.tsx
+++ b/src/components/PubkySetup/Welcome.tsx
@@ -1,10 +1,10 @@
 import React, { memo, ReactElement, useCallback, useMemo } from 'react';
 import { StyleSheet, Image, Linking, View } from 'react-native';
+import { Trans, useTranslation } from 'react-i18next';
 import PubkyRingLogo from '../../images/pubky-app-logo.png';
 import { PUBKY_APP_URL } from '../../utils/constants.ts';
 import { isSmallScreen } from '../../utils/helpers.ts';
-import { useTranslation } from 'react-i18next';
-import { BodyMText, BoldText, DisplayText } from '../../theme/typography';
+import { BodyMBText, BodyMText, DisplayText } from '../../theme/typography';
 import Button from '../Button.tsx';
 
 const BUTTON_TEXT = PUBKY_APP_URL.replace('https://', '');
@@ -52,9 +52,14 @@ const Welcome = ({
 	return (
 		<View style={styles.content}>
 			<DisplayText style={styles.headerText}>{t('welcome.welcome')}</DisplayText>
+
 			<BodyMText style={styles.message}>
-				{t('welcome.homeserverMessageStart')} <BoldText>{truncatedPubky}</BoldText>{' '}
-				{t('welcome.homeserverMessageEnd')}
+				<Trans
+					t={t}
+					i18nKey="welcome.message"
+					components={{ accent: <BodyMBText colorName="textPrimary" /> }}
+					values={{ pubky: truncatedPubky }}
+				/>
 			</BodyMText>
 
 			<View style={styles.tagContainer}>

--- a/src/components/RecoveryPhrasePrompt.tsx
+++ b/src/components/RecoveryPhrasePrompt.tsx
@@ -27,8 +27,6 @@ const RecoveryPhrasePrompt = ({
 	const [isBlurred, setIsBlurred] = useState<boolean>(true);
 	const pubkyName = useSelector((state: RootState) => getPubkyName(state, payload.pubky, 12));
 	const { confirmPubkyBackup } = usePubkyManagement();
-	const title = t('backup.recoveryPhrase');
-	const message = t('backup.recoveryPhraseMessage');
 
 	const mnemonicWords = useMemo(() => {
 		if (!payload?.mnemonic) {
@@ -49,8 +47,8 @@ const RecoveryPhrasePrompt = ({
 	};
 
 	return (
-		<Sheet id="recovery-phrase-prompt" title={title}>
-			<BodyMText style={styles.message}>{message}</BodyMText>
+		<Sheet id="recovery-phrase-prompt" title={t('backup.mnemonic.navTitle')}>
+			<BodyMText style={styles.message}>{t('backup.recoveryPhraseMessage')}</BodyMText>
 
 			<View style={styles.mnemonicContainer}>
 				<View style={styles.columnContainer}>

--- a/src/components/SelectBackupPreference.tsx
+++ b/src/components/SelectBackupPreference.tsx
@@ -1,20 +1,19 @@
 import React, { memo, ReactElement } from 'react';
 import { Image, StyleSheet, View } from 'react-native';
-import Button from '../components/Button.tsx';
+import { Trans, useTranslation } from 'react-i18next';
 import { SheetManager } from 'react-native-actions-sheet';
+import Button from '../components/Button.tsx';
 import { EBackupPreference } from '../types/pubky.ts';
 import { showBackupPrompt } from '../utils/sheetHelpers.ts';
 import { truncateStr } from '../utils/pubky.ts';
-import { BodyMText, DisplayText } from '../theme/typography';
+import { BodyMBText, BodyMText, DisplayText } from '../theme/typography';
 import Sheet from './Sheet.tsx';
-import { useTranslation } from 'react-i18next';
 
 const BACKUP_PROMPT_DELAY = 250;
 
 const SelectBackupPreference = ({ payload: { pubky } }: { payload: { pubky: string } }): ReactElement => {
 	const { t } = useTranslation();
 	const truncatedPubky = truncateStr(pubky).replace(/^pk:/, '');
-	const messageText = t('selectBackup.message', { pubky: truncatedPubky });
 
 	const selectPreference = (backupPreference: EBackupPreference): void => {
 		void SheetManager.hide('select-backup-preference');
@@ -34,7 +33,15 @@ const SelectBackupPreference = ({ payload: { pubky } }: { payload: { pubky: stri
 	return (
 		<Sheet id="select-backup-preference" gradientType="brand" title={t('selectBackup.title')}>
 			<DisplayText style={styles.headerText}>{t('selectBackup.header')}</DisplayText>
-			<BodyMText>{messageText}</BodyMText>
+
+			<Trans
+				t={t}
+				i18nKey="selectBackup.message"
+				parent={BodyMText}
+				components={{ accent: <BodyMBText colorName="textPrimary" /> }}
+				values={{ pubky: truncatedPubky }}
+			/>
+
 			<View style={styles.imageContainer}>
 				<Image source={require('../images/shield.png')} style={styles.image} />
 			</View>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -108,7 +108,7 @@
 		"deletePubky": "Delete Pubky",
 		"deleteConfirm": "Are you sure you want to delete this pubky?",
 		"selectPubky": "Select Pubky",
-		"selectPubkyMessage": "Select which pubky you want to use to authorize this service, browser or device.",
+		"selectPubkyMessage": "Select which pubky you want to use to authorize this service, browser, or device.",
 		"noPubkysAvailable": "You do not have any pubky's that are setup and available. Please create and setup a pubky first.",
 		"yourPubky": "Your pubky.",
 		"yourPubkyDescription": "This is your first unique identifier, your pubky. Create as many as you need for different purposes. You are your keys.",
@@ -119,28 +119,34 @@
 		"successfullyCreated": "Successfully created pubky."
 	},
 	"backup": {
-		"encryptedFile": "Encrypted File",
 		"backup": "Backup",
-		"createBackup": "Create Backup",
+		"createBackup": "Create backup",
 		"backupMessage": "Enter a password or passphrase to encrypt and secure your backup. Keep it safe, you'll need it to restore your pubky.",
 		"importMessage": "Enter your password or passphrase to decrypt your pubky backup.",
-		"passphraseFor": "Passphrase for ",
+		"passphraseFor": "Passphrase for <accent>{{pubky}}</accent>",
 		"enterPassphrase": "Enter passphrase",
 		"passwordMinLength": "Password must be at least {{min}} {{chars}} long",
 		"character": "character",
 		"characters": "characters",
-		"recoveryPhrase": "Recovery Phrase",
+		"encryptedFile": "Encrypted file",
+		"recoveryPhrase": "Recovery phrase",
 		"recoveryPhraseMessage": "Write down these 12 words in the right order and store them in a safe place.",
 		"tapToReveal": "Tap to reveal",
 		"recoveryWarning": "Never share your recovery phrase with anyone as this may result in the loss of access to your profile, data, and online identity.",
 		"finishBackup": "Finish backup",
 		"couldNotRetrieveSecretKey": "Could not retrieve secret key for backup",
 		"backupCreated": "Backup Created",
-		"failedToCreateBackup": "Failed to create backup file"
+		"failedToCreateBackup": "Failed to create backup file",
+		"file": {
+			"navTitle": "Encrypted File"
+		},
+		"mnemonic": {
+			"navTitle": "Recovery Phrase"
+		}
 	},
 	"onboarding": {
 		"title": "Keychain for the next web.",
-		"getStarted": "Get Started"
+		"getStarted": "Get started"
 	},
 	"editPubky": {
 		"enterName": "Enter name",
@@ -150,8 +156,7 @@
 	"welcome": {
 		"defaultHomeserver": "Default Homeserver",
 		"welcome": "Welcome.",
-		"homeserverMessageStart": "Your invite code is valid. Your pubky",
-		"homeserverMessageEnd": "is now configured to use the Synonym homeserver for data hosting.",
+		"message": "Your invite code is valid. Your pubky <accent>{{pubky}}</accent> is now configured to use the Synonym homeserver for data hosting.",
 		"openButton": "Open {{domain}}"
 	},
 	"session": {
@@ -189,8 +194,8 @@
 	},
 	"terms": {
 		"title": "Terms of Use.",
-		"acceptTerms": "I declare that I have read and accept the terms of use.",
-		"acceptPrivacy": "I declare that I have read and accept the ",
+		"acceptTerms": "By continuing you declare that you have read and accept the terms of use.",
+		"acceptPrivacy": "By continuing you declare that you have read and accept the <accent>privacy policy.</accent>",
 		"termsOfUse": "Terms of Use",
 		"privacyPolicy": "Privacy Policy"
 	},
@@ -214,12 +219,14 @@
 		"title": "Add Pubky",
 		"yourKeysYourIdentity": "Your keys,\nyour identity.",
 		"restoreOrImport": "Restore or\nimport pubky.",
-		"createOrImportQuestion": "Do you want to create a new pubky or import an existing one?",
+		"createOrImportQuestion": "Scan a signup QR for instant onboarding, add a pubky manually, or import one.",
 		"chooseBackupMethod": "Choose the backup method you used.",
 		"enterRecoveryWords": "Enter the 12 words from your recovery \nphrase to import or restore your pubky.",
-		"importPubkyButton": "Import pubky",
+		"importPubkyButton": "Import existing",
 		"scanSignupQr": "Scan signup QR",
 		"newPubkyButton": "Set up manually",
+		"encryptedFile": "Encrypted file",
+		"recoveryPhrase": "Recovery phrase",
 		"scanQrToImport": "Scan import QR"
 	},
 	"editPubkySheet": {
@@ -240,7 +247,7 @@
 	"selectBackup": {
 		"title": "Backup Pubky",
 		"header": "Safely backup\nyour pubky.",
-		"message": "Choose your preferred backup method for pubky {{pubky}} to restore access if you lose your phone or your data."
+		"message": "Choose your preferred backup method for pubky <accent>{{pubky}}</accent> to restore access if you lose your phone or your data."
 	},
 	"router": {
 		"importSuccessful": "Import successful",
@@ -296,7 +303,7 @@
 	"homeserver": {
 		"title": "Homeserver",
 		"dataHosting": "Data hosting.",
-		"chooseMessage": "Choose a homeserver to host your data for pubky",
+		"message": "Choose a homeserver to host your data for pubky <accent>{{pubky}}</accent>",
 		"label": "HOMESERVER",
 		"default": "Default",
 		"requiresInvite": "(requires invite code)",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -124,7 +124,7 @@
 		"createBackup": "Crear copia de seguridad",
 		"backupMessage": "Introduzca una contraseña o frase de contraseña para encriptar y asegurar su copia de seguridad. Manténgala a salvo, la necesitará para restaurar su pubky.",
 		"importMessage": "Introduzca su contraseña o frase de contraseña para descifrar su copia de seguridad pubky.",
-		"passphraseFor": "Frase de contraseña para ",
+		"passphraseFor": "Frase de contraseña para <accent>{{pubky}}</accent>",
 		"enterPassphrase": "Introduzca la contraseña",
 		"passwordMinLength": "La contraseña debe tener una longitud mínima de {{min}} {{chars}} ",
 		"character": "carácter",
@@ -136,7 +136,13 @@
 		"finishBackup": "Finalizar la copia de seguridad",
 		"couldNotRetrieveSecretKey": "No se ha podido recuperar la clave secreta para la copia de seguridad",
 		"backupCreated": "Copia de seguridad creada",
-		"failedToCreateBackup": "Fallo al crear el archivo de copia de seguridad"
+		"failedToCreateBackup": "Fallo al crear el archivo de copia de seguridad",
+		"file": {
+			"navTitle": "Archivo cifrado"
+		},
+		"mnemonic": {
+			"navTitle": "Frase de recuperación"
+		}
 	},
 	"onboarding": {
 		"title": "Llavero para la próxima web.",
@@ -150,8 +156,7 @@
 	"welcome": {
 		"defaultHomeserver": "Servidor doméstico predeterminado",
 		"welcome": "Bienvenida.",
-		"homeserverMessageStart": "Su código de invitación es válido. Su pubky",
-		"homeserverMessageEnd": "está ahora configurado para utilizar el servidor doméstico de Synonym para el alojamiento de datos.",
+		"message": "Su código de invitación es válido. Su pubky <accent>{{pubky}}</accent> está configurado para usar el homeserver de Synonym para alojar sus datos.",
 		"openButton": "Abra {{domain}}"
 	},
 	"session": {
@@ -189,8 +194,8 @@
 	},
 	"terms": {
 		"title": "Condiciones de uso.",
-		"acceptTerms": "Declaro que he leído y acepto las condiciones de uso.",
-		"acceptPrivacy": "Declaro que he leído y acepto el ",
+		"acceptTerms": "Al continuar, declara que ha leído y acepta las condiciones de uso.",
+		"acceptPrivacy": "Al continuar, declara que ha leído y acepta la <accent>política de privacidad.</accent>",
 		"termsOfUse": "Condiciones de uso",
 		"privacyPolicy": "Política de privacidad"
 	},
@@ -215,11 +220,14 @@
 		"title": "Añadir Pubky",
 		"yourKeysYourIdentity": "Sus llaves,\nsu identidad.",
 		"restoreOrImport": "Restaurar o\nimportar pubky.",
-		"createOrImportQuestion": "¿Desea crear un nuevo pubky o importar uno existente?",
+		"createOrImportQuestion": "Escanee un QR de registro para empezar al instante, añada un pubky manualmente o importe uno.",
 		"chooseBackupMethod": "Elija el método de copia de seguridad utilizado.",
 		"enterRecoveryWords": "Introduzca las 12 palabras de su recuperación \nfrase para importar o restaurar su pubky.",
-		"importPubkyButton": "Importar pubky",
-		"newPubkyButton": "Nuevo pubky",
+		"importPubkyButton": "Importar existente",
+		"scanSignupQr": "Escanear QR de registro",
+		"newPubkyButton": "Configurar manualmente",
+		"encryptedFile": "Archivo cifrado",
+		"recoveryPhrase": "Frase de recuperación",
 		"scanQrToImport": "Escanear QR para importar"
 	},
 	"editPubkySheet": {
@@ -240,7 +248,7 @@
 	"selectBackup": {
 		"title": "Copia de seguridad Pubky",
 		"header": "Haga una copia de seguridad segura\nde su pubky.",
-		"message": "Elija el método de copia de seguridad que prefiera para pubky {{pubky}} para restaurar el acceso si pierde su teléfono o sus datos."
+		"message": "Elija el método de copia de seguridad que prefiera para pubky <accent>{{pubky}}</accent> y restaure el acceso si pierde el teléfono o los datos."
 	},
 	"router": {
 		"importSuccessful": "Importación correcta",
@@ -296,7 +304,7 @@
 	"homeserver": {
 		"title": "Homeserver",
 		"dataHosting": "Alojamiento de datos.",
-		"chooseMessage": "Elija un servidor doméstico para alojar sus datos para pubky",
+		"message": "Elija un homeserver para alojar los datos de pubky <accent>{{pubky}}</accent>",
 		"label": "HOMESERVER",
 		"default": "Por defecto",
 		"requiresInvite": "(requiere código de invitación)",

--- a/src/screens/TermsOfUse.tsx
+++ b/src/screens/TermsOfUse.tsx
@@ -10,7 +10,7 @@ import { updateSignedTermsOfUse } from '../store/slices/settingsSlice.ts';
 import { getHasPubkys } from '../store/selectors/pubkySelectors.ts';
 import { getShowOnboarding } from '../store/selectors/settingsSelectors.ts';
 import { useTypedNavigation } from '../navigation/hooks';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import Button from '../components/Button.tsx';
 import TermsOfUseContent from '../components/TermsOfUseContent.tsx';
 import SafeAreaInset from '../components/SafeAreaInset.tsx';
@@ -68,11 +68,11 @@ const TermsOfUse = (): React.ReactElement => {
 					<View>
 						<BodyMSBText style={styles.footerHeaderText}>{t('terms.privacyPolicy')}</BodyMSBText>
 						<BodySSBText colorName="textTertiary">
-							{t('terms.acceptPrivacy')}
-							<BodySSBText colorName="pubkyRing" style={styles.linkText} onPress={onPrivacyFormPress}>
-								{t('terms.privacyPolicy')}
-							</BodySSBText>
-							.
+							<Trans
+								t={t}
+								i18nKey="terms.acceptPrivacy"
+								components={{ accent: <BodySSBText colorName="pubkyRing" onPress={onPrivacyFormPress} /> }}
+							/>
 						</BodySSBText>
 					</View>
 

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -8,17 +8,17 @@ interface TypographyProps {
 	colorName?: ThemeColorName;
 }
 
-const textColor = ({ color, colorName = 'textPrimary', theme }: TypographyProps & { theme: Theme }): string => {
+const textColor = ({
+	color,
+	colorName = 'textPrimary',
+	theme,
+}: TypographyProps & { theme: Theme }): string => {
 	return color ?? theme.colors[colorName];
 };
 
 const BaseText = styled.Text<TypographyProps>`
 	color: ${textColor};
 	font-family: ${fontFamily};
-`;
-
-export const BoldText = styled(BaseText)`
-	font-weight: bold;
 `;
 
 export const DisplayText = styled(BaseText)`


### PR DESCRIPTION
## Summary

- Updates copy across onboarding, add/import pubky, backup, homeserver setup, and terms screens.
- Refactors dynamic translated sentences to use `Trans` so highlighted pubky values and the privacy policy link stay correctly positioned in each locale.
- Syncs Spanish translations with the updated English locale keys and adds missing Spanish copy for the new backup/import labels.
- Removes the generic `BoldText` helper in favor of existing typed typography components.

Closes https://github.com/pubky/pubky-ring/issues/310