### PR TITLE
test(e2e): setup Maestro for Android

### DIFF
--- a/.github/scripts/android-e2e.sh
+++ b/.github/scripts/android-e2e.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap 'adb logcat -d > "$GITHUB_WORKSPACE/android-logcat.txt" || true' EXIT
+
+cd "$GITHUB_WORKSPACE/android"
+./gradlew :app:assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon
+adb install -r app/build/outputs/apk/release/app-release.apk
+
+cd "$GITHUB_WORKSPACE"
+INVITE_CODE="$(
+  curl --fail --silent --show-error \
+    -H "X-Admin-Password: $HOMESERVER_ADMIN_PASSWORD" \
+    -H "Content-Type: application/json" \
+    https://admin.homeserver.staging.pubky.app/generate_signup_token
+)"
+INVITE_CODE_COMPACT="${INVITE_CODE//-/}"
+echo "::add-mask::$INVITE_CODE"
+echo "::add-mask::$INVITE_CODE_COMPACT"
+
+maestro --platform=android test -e APP_ID=to.pubky.ring -e INVITE_CODE="$INVITE_CODE" .maestro

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -1,0 +1,99 @@
+name: Android E2E Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      commit-sha:
+        description: 'Commit SHA to build/test (leave empty to use selected branch)'
+        required: false
+        type: string
+
+concurrency:
+  group: android-e2e-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      MAESTRO_CLI_NO_ANALYTICS: "true"
+      MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: "true"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.inputs.commit-sha || github.ref }}
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: '24'
+        cache: 'yarn'
+
+    - name: Set up Java
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'zulu'
+        java-version: '17'
+
+    - name: Set up Gradle cache
+      uses: gradle/actions/setup-gradle@v5
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Install Maestro
+      run: |
+        curl -Ls "https://get.maestro.mobile.dev" | bash
+        echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+    - name: Build app and run Maestro flows
+      uses: reactivecircus/android-emulator-runner@v2.35.0
+      env:
+        HOMESERVER_ADMIN_PASSWORD: ${{ secrets.HOMESERVER_ADMIN_PASSWORD }}
+      with:
+        api-level: 36
+        arch: x86_64
+        profile: pixel_7
+        ndk: 27.1.12297006
+        emulator-options: -no-window -gpu swangle -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none
+        disable-animations: true
+        script: bash .github/scripts/android-e2e.sh
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: android-release-apk
+        path: android/app/build/outputs/apk/release/app-release.apk
+        if-no-files-found: ignore
+        retention-days: 7
+
+    - name: Upload Maestro results
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: android-e2e-results
+        path: .maestro/results/
+        if-no-files-found: ignore
+        retention-days: 7
+
+    - name: Upload Logcat
+      uses: actions/upload-artifact@v7
+      if: failure()
+      with:
+        name: android-e2e-logcat
+        path: android-logcat.txt
+        if-no-files-found: ignore
+        retention-days: 7

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,6 +1,6 @@
 # Maestro E2E
 
-This is the iOS simulator E2E suite.
+This is the Maestro E2E suite for iOS simulators and Android emulators.
 
 ## Local iOS
 
@@ -18,8 +18,26 @@ The custom homeserver flow also requires:
 HOMESERVER_ADMIN_PASSWORD=... yarn e2e:ios
 ```
 
+## Local Android
+
+1. Install Maestro: `curl -Ls "https://get.maestro.mobile.dev" | bash`
+2. Build and install the Android app on an emulator.
+3. Run:
+
+```sh
+yarn e2e:android
+```
+
+The custom homeserver flow also requires:
+
+```sh
+HOMESERVER_ADMIN_PASSWORD=... yarn e2e:android
+```
+
 ## Continuous Integration
 
 `.github/workflows/ios-e2e.yml` builds the iOS simulator app, installs Maestro, boots an iPhone 17 simulator, installs the app, and runs all flows in `.maestro`.
 
-CI requests the staging invite code before invoking Maestro, so the homeserver admin password is not written into Maestro output.
+`.github/workflows/android-e2e.yml` builds the Android APK inside an emulator job, installs Maestro, installs the app, and runs the same flows in `.maestro`.
+
+CI requests the staging invite code before invoking Maestro, so the homeserver admin password is not written into Maestro output. Uploaded Maestro results can include the generated single-run invite code.

--- a/.maestro/flows/create-pubky-custom-homeserver.yaml
+++ b/.maestro/flows/create-pubky-custom-homeserver.yaml
@@ -23,20 +23,19 @@ env:
     timeout: 30000
 - tapOn:
     id: EditPubkyNameInput
-- eraseText: 100
 - inputText: ${PUBKY_NAME}
 - assertVisible: ${PUBKY_NAME}
 - tapOn:
     id: EditPubkyInviteCodeInput
-- eraseText: 100
 - inputText: ${output.INVITE_CODE_WITHOUT_HYPHENS}
-- assertVisible:
-    id: EditPubkyInviteCodeInput
+- runFlow:
+    file: ../shared/clearInputText.yaml
+    env:
+      INPUT_ID: EditPubkyHomeserverInput
+- setClipboard: ${STAGING_HOMESERVER}
+- pasteText
 - tapOn:
-    id: EditPubkyHomeserverInput
-- eraseText: 100
-- inputText: ${STAGING_HOMESERVER}
-- hideKeyboard
+    id: EditPubkyNameLabel # hide keyboard
 - tapOn:
     id: EditPubkySaveButton
 - assertVisible:

--- a/.maestro/flows/create-pubky-default-homeserver.yaml
+++ b/.maestro/flows/create-pubky-default-homeserver.yaml
@@ -11,10 +11,6 @@ name: create-pubky-default-homeserver
     id: HomeserverCustomRadioInner
 - tapOn:
     id: HomeserverContinueButton
-- assertVisible:
-    id: InviteCodeInput
-- assertVisible:
-    id: InviteCodeContinueButton
 - tapOn:
     id: InviteCodeInput
 - inputText: ABCD1234EFGH

--- a/.maestro/shared/clearInputText.yaml
+++ b/.maestro/shared/clearInputText.yaml
@@ -1,0 +1,24 @@
+# This helper flow clears the text from an input field reliably on both platforms.
+
+appId: ${APP_ID}
+---
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - longPressOn:
+          id: ${INPUT_ID}
+      - tapOn:
+          text: "Select All"
+          optional: true
+      - eraseText: 1
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - doubleTapOn:
+          id: ${INPUT_ID}
+          delay: 500
+      - tapOn:
+          text: "Select All"
+      - eraseText: 1

--- a/README.md
+++ b/README.md
@@ -122,19 +122,21 @@ gpg --verify SHA256SUMS.asc
 sha256sum -c SHA256SUMS
 ```
 
-## iOS E2E testing (Maestro)
+## E2E testing (Maestro)
 
-This project currently runs iOS simulator E2E tests with Maestro. Android CI is omitted while the iOS path is established.
+This project runs iOS simulator and Android emulator E2E tests with Maestro.
 
 ### Prerequisites
 - Xcode with an iOS Simulator.
+- Android SDK with an emulator.
 - Maestro installed locally: `curl -Ls "https://get.maestro.mobile.dev" | bash`.
-- The Release app built and installed on the simulator.
+- The app built and installed on the target simulator or emulator.
 
 ### Run tests
 
 ```bash
 yarn e2e:ios
+yarn e2e:android
 ```
 
 ### Environment overrides
@@ -146,6 +148,10 @@ yarn e2e:ios
 # Run all iOS flows against the installed app
 yarn e2e:ios
 
+# Run all Android flows against the installed app
+yarn e2e:android
+
 # Run flows that request a staging invite code
 HOMESERVER_ADMIN_PASSWORD=... yarn e2e:ios
+HOMESERVER_ADMIN_PASSWORD=... yarn e2e:android
 ```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "icons:build": "node scripts/build-icons.mjs",
     "optimize-images": "node scripts/optimize-images.js",
     "test": "jest",
+    "e2e:android": "MAESTRO_CLI_NO_ANALYTICS=true MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true maestro --platform=android test -e APP_ID=to.pubky.ring -e HOMESERVER_ADMIN_PASSWORD=\"$HOMESERVER_ADMIN_PASSWORD\" .maestro",
     "e2e:ios": "MAESTRO_CLI_NO_ANALYTICS=true MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true maestro --platform=ios test -e APP_ID=app.pubkyring -e HOMESERVER_ADMIN_PASSWORD=\"$HOMESERVER_ADMIN_PASSWORD\" .maestro",
     "tx:push": "./tx push -s",
     "tx:pull": "./tx pull -a",

--- a/src/components/EditPubky.tsx
+++ b/src/components/EditPubky.tsx
@@ -348,7 +348,7 @@ const EditPubky = ({
 	return (
 		<Sheet id="edit-pubky" title={title} keyboardHandlerEnabled={false}>
 			<ActionSheetScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
-				<CaptionText>{i18n.t('editPubkySheet.pubkyNameLabel')}</CaptionText>
+				<CaptionText testID="EditPubkyNameLabel">{i18n.t('editPubkySheet.pubkyNameLabel')}</CaptionText>
 				<InputItemComponent
 					testID="EditPubkyNameInput"
 					value={newPubkyName}
@@ -361,9 +361,7 @@ const EditPubky = ({
 
 				{isSignupTokenInputVisible && (
 					<>
-						<CaptionText>
-							{i18n.t('editPubkySheet.inviteCodeOptional')}
-						</CaptionText>
+						<CaptionText>{i18n.t('editPubkySheet.inviteCodeOptional')}</CaptionText>
 						<InputItemComponent
 							testID="EditPubkyInviteCodeInput"
 							inputRef={signupTokenInputRef}

--- a/src/components/PubkySetup/InviteCode.tsx
+++ b/src/components/PubkySetup/InviteCode.tsx
@@ -200,6 +200,7 @@ const InviteCode = ({
 					maxLength={14}
 					editable={!loading}
 					autoFocus={true}
+					returnKeyType="done"
 				/>
 				<Animated.View style={inputCheckmarkStyle}>
 					<CheckCircle colorName="pubkyRing" size={32} />

--- a/src/components/PubkySetup/NewPubkySetup.tsx
+++ b/src/components/PubkySetup/NewPubkySetup.tsx
@@ -70,7 +70,7 @@ const Content = ({
 				/>
 			);
 		case ECurrentScreen.requestInvite:
-			return <RequestInviteCode />
+			return <RequestInviteCode />;
 		case ECurrentScreen.welcome:
 			return (
 				<Welcome
@@ -139,6 +139,7 @@ const NewPubkySetup = ({
 			id="new-pubky-setup"
 			title={title}
 			gradientType="brand"
+			keyboardHandlerEnabled={false}
 			onBackPress={currentScreen === ECurrentScreen.requestInvite ? handleBackPress : undefined}
 		>
 			<Content


### PR DESCRIPTION
## Summary

Adds Android support to the Maestro E2E suite.

## Changes

- Adds an `android-e2e` GitHub Actions workflow.
- Builds and installs the Android APK on an emulator.
- Runs Maestro against `to.pubky.ring`.
- Adds `yarn e2e:android` for local runs.
- Adds a shared input-clearing helper for iOS/Android differences.
- Updates invite-code flows for Android keyboard behavior.
- Documents Android E2E usage.
