### PR TITLE
fix: show native app version on About screen

### DIFF
--- a/android/app/src/main/java/com/pubkyring/AppInfoModule.kt
+++ b/android/app/src/main/java/com/pubkyring/AppInfoModule.kt
@@ -1,0 +1,14 @@
+package to.pubkyring
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+
+class AppInfoModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName(): String = "AppInfo"
+
+  override fun getConstants(): Map<String, Any> =
+      mapOf(
+          "version" to BuildConfig.VERSION_NAME,
+          "buildNumber" to BuildConfig.VERSION_CODE.toString(),
+      )
+}

--- a/android/app/src/main/java/com/pubkyring/AppInfoPackage.kt
+++ b/android/app/src/main/java/com/pubkyring/AppInfoPackage.kt
@@ -1,0 +1,16 @@
+package to.pubkyring
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class AppInfoPackage : ReactPackage {
+  @Suppress("OVERRIDE_DEPRECATION")
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+      listOf(AppInfoModule(reactContext))
+
+  override fun createViewManagers(
+      reactContext: ReactApplicationContext
+  ): List<ViewManager<*, *>> = emptyList()
+}

--- a/android/app/src/main/java/com/pubkyring/MainApplication.kt
+++ b/android/app/src/main/java/com/pubkyring/MainApplication.kt
@@ -16,7 +16,7 @@ class MainApplication : Application(), ReactApplication {
       packageList =
         PackageList(this).packages.apply {
           // Packages that cannot be autolinked yet can be added manually here, for example:
-          // add(MyReactNativePackage())
+          add(AppInfoPackage())
         },
     )
   }

--- a/ios/pubkyring.xcodeproj/project.pbxproj
+++ b/ios/pubkyring.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1319212F6007D5772A620B61 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		4B1A7B8D2C3D4E5F00112233 /* AppInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B1A7B8C2C3D4E5F00112233 /* AppInfo.m */; };
 		70F9B56BE652426C904D16F4 /* InterTight-VariableFont_wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C21B8554B47148DBBCC60B15 /* InterTight-VariableFont_wght.ttf */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
@@ -20,6 +21,7 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = pubkyring/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = pubkyring/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = pubkyring/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		4B1A7B8C2C3D4E5F00112233 /* AppInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = AppInfo.m; path = pubkyring/AppInfo.m; sourceTree = "<group>"; };
 		5F66FC2D5C5C4019367FA619 /* libPods-pubkyring.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-pubkyring.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = pubkyring/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = pubkyring/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -45,6 +47,7 @@
 			isa = PBXGroup;
 			children = (
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				4B1A7B8C2C3D4E5F00112233 /* AppInfo.m */,
 				761780EC2CA45674006654EE /* AppDelegate.swift */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
@@ -258,6 +261,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4B1A7B8D2C3D4E5F00112233 /* AppInfo.m in Sources */,
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/pubkyring/AppInfo.m
+++ b/ios/pubkyring/AppInfo.m
@@ -1,0 +1,27 @@
+#import <React/RCTBridgeModule.h>
+
+@interface AppInfo : NSObject <RCTBridgeModule>
+@end
+
+@implementation AppInfo
+
+RCT_EXPORT_MODULE();
+
+- (NSDictionary *)constantsToExport
+{
+  NSBundle *bundle = NSBundle.mainBundle;
+  NSString *version = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"";
+  NSString *buildNumber = [bundle objectForInfoDictionaryKey:@"CFBundleVersion"] ?: @"";
+
+  return @{
+    @"version": version,
+    @"buildNumber": buildNumber
+  };
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+@end

--- a/src/screens/About.tsx
+++ b/src/screens/About.tsx
@@ -1,7 +1,6 @@
 import React, { memo, ReactElement } from 'react';
 import { Image, Linking, StyleSheet, TouchableOpacity, ScrollView, View } from 'react-native';
 import AppHeader, { HEADER_HEIGHT } from '../components/AppHeader.tsx';
-import { version } from '../../package.json';
 import PubkyRingLogo from '../images/pubky-app-logo.png';
 import BrandEndoresment from '../images/brand-endorsement.png';
 import { PUBKY_APP_URL, TERMS_OF_USE } from '../utils/constants.ts';
@@ -11,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { BodyMSBText, BodyMSpacedText, BodyMText, DisplayText } from '../theme/typography.ts';
 import SafeAreaInset from '../components/SafeAreaInset.tsx';
 import { ChevronRight } from '../icons/index.ts';
+import { appVersion } from '../utils/appInfo.ts';
 
 const About = (): ReactElement => {
 	const { t } = useTranslation();
@@ -38,11 +38,11 @@ const About = (): ReactElement => {
 	};
 
 	const onCopyPress = (): void => {
-		copyToClipboard(version);
+		copyToClipboard(appVersion);
 		showToast({
 			type: 'info',
 			title: t('about.copiedVersion'),
-			description: `${t('about.version')}: ${version}`,
+			description: `${t('about.version')}: ${appVersion}`,
 		});
 	};
 	return (
@@ -67,7 +67,7 @@ const About = (): ReactElement => {
 
 				<TouchableOpacity activeOpacity={0.8} onPress={onCopyPress} style={styles.row}>
 					<BodyMSpacedText>{t('about.version')}</BodyMSpacedText>
-					<BodyMSpacedText colorName="textTertiary">{version}</BodyMSpacedText>
+					<BodyMSpacedText colorName="textTertiary">{appVersion}</BodyMSpacedText>
 				</TouchableOpacity>
 
 				<Image source={BrandEndoresment} style={styles.brandLogo} />

--- a/src/utils/appInfo.ts
+++ b/src/utils/appInfo.ts
@@ -1,0 +1,11 @@
+import { NativeModules } from 'react-native';
+
+type AppInfoConstants = {
+	version?: string;
+	buildNumber?: string;
+};
+
+const appInfo = NativeModules.AppInfo as AppInfoConstants | undefined;
+
+export const appVersion = appInfo?.version ?? '';
+export const appBuildNumber = appInfo?.buildNumber ?? '';


### PR DESCRIPTION
### Description

Shows the native app version on the About screen instead of the npm package version.

### Changes

- Add a small native `AppInfo` bridge on iOS and Android to expose the app version and build number from each platform.
- Read iOS `CFBundleShortVersionString` / `CFBundleVersion` and Android `BuildConfig.VERSION_NAME` / `VERSION_CODE`.
- Update the About screen version row and copy-to-clipboard action to use the native user-facing version.
- Register the Android native package and add the iOS module to the Xcode project sources.

<img width="350" alt="Simulator Screenshot - iPhone 17 Clean 26 5 - 2026-06-04 at 19 06 24" src="https://github.com/user-attachments/assets/510fc845-c602-46e9-b6b3-6665bc282d60" />

<img width="350" alt="Screenshot_1780592783" src="https://github.com/user-attachments/assets/4a5bfdf7-c812-4712-95e7-a742e895ab17" />
