### PR TITLE
test: e2e flows

### DIFF
--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -2,9 +2,3 @@ appId: ${APP_ID}
 flows:
   - flows/*.yaml
 testOutputDir: .maestro/results
-executionOrder:
-  continueOnFailure: false
-  flowsOrder:
-    - onboarding
-    - create-pubky-default-homeserver
-    - create-pubky-custom-homeserver

--- a/.maestro/flows/create-pubky-and-authorize.yaml
+++ b/.maestro/flows/create-pubky-and-authorize.yaml
@@ -1,0 +1,12 @@
+appId: ${APP_ID}
+name: create-pubky-and-authorize
+env:
+  AUTH_URL: pubkyring://signin?relay=https%3A%2F%2Frelay.staging.pubky.app&secret=maestro-auth-secret&caps=%2Fpub%2Fpubky.app%2F%3Arw&x-source=Maestro
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow: ../shared/create-pubky.yaml
+- runFlow: ../shared/close-sheet.yaml
+- runFlow: ../shared/signup.yaml
+- runFlow: ../shared/authorize.yaml

--- a/.maestro/flows/create-pubky-default-homeserver.yaml
+++ b/.maestro/flows/create-pubky-default-homeserver.yaml
@@ -4,7 +4,7 @@ name: create-pubky-default-homeserver
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
-- runFlow: ../shared/start-new-pubky.yaml
+- runFlow: ../shared/create-pubky.yaml
 - assertVisible:
     id: HomeserverDefaultRadioInner
 - assertNotVisible:

--- a/.maestro/flows/import-pubky-mnemonic.yaml
+++ b/.maestro/flows/import-pubky-mnemonic.yaml
@@ -1,0 +1,66 @@
+appId: ${APP_ID}
+name: import-pubky-mnemonic
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- tapOn:
+    id: AddPubkyButton
+- waitForAnimationToEnd
+- assertVisible:
+    id: add-pubky-title
+- tapOn:
+    id: AddPubkyImport
+    # retryTapIfNoChange: true
+- waitForAnimationToEnd
+- assertVisible:
+    id: RecoveryPhraseButton
+- tapOn:
+    id: RecoveryPhraseButton
+    # retryTapIfNoChange: true
+- waitForAnimationToEnd
+- assertVisible:
+    id: MnemonicWordInput-1
+- tapOn:
+    id: MnemonicWordInput-1
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-2
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-3
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-4
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-5
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-6
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-7
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-8
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-9
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-10
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-11
+- inputText: abandon
+- tapOn:
+    id: MnemonicWordInput-12
+- inputText: about
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: import-success-title
+    timeout: 30000
+- tapOn:
+    id: ImportSuccessButton

--- a/.maestro/flows/migrate-keys.yaml
+++ b/.maestro/flows/migrate-keys.yaml
@@ -1,0 +1,20 @@
+appId: ${APP_ID}
+name: migrate-keys
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow:
+    file: ../shared/open-link.yaml
+    env:
+      URL: "pubkyring://migrate?index=0&total=2&key=abandon%20abandon%20abandon%20abandon%20abandon%20abandon%20abandon%20abandon%20abandon%20abandon%20abandon%20about"
+- runFlow:
+    file: ../shared/open-link.yaml
+    env:
+      URL: "pubkyring://migrate?index=1&total=2&key=legal%20winner%20thank%20year%20wave%20sausage%20worth%20useful%20legal%20winner%20thank%20yellow"
+- extendedWaitUntil:
+    visible:
+      id: PubkyBox--0
+    timeout: 120000
+- assertVisible:
+    id: PubkyBox--1

--- a/.maestro/shared/authorize.yaml
+++ b/.maestro/shared/authorize.yaml
@@ -1,0 +1,18 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: open-link.yaml
+    env:
+      URL: ${AUTH_URL}
+- assertVisible:
+    id: confirm-auth-title
+- assertVisible:
+    id: ConfirmAuthRequestedPermissions
+- tapOn:
+    id: ConfirmAuthAuthorizeButton
+- extendedWaitUntil:
+    visible:
+      id: ConfirmAuthSuccessButton
+    timeout: 30000
+- tapOn:
+    id: ConfirmAuthSuccessButton

--- a/.maestro/shared/clear-input-text.yaml
+++ b/.maestro/shared/clear-input-text.yaml
@@ -20,5 +20,9 @@ appId: ${APP_ID}
           id: ${INPUT_ID}
           delay: 500
       - tapOn:
+          text: "Cut"
+          optional: true
+      - tapOn:
           text: "Select All"
+          optional: true
       - eraseText: 1

--- a/.maestro/shared/close-sheet.yaml
+++ b/.maestro/shared/close-sheet.yaml
@@ -1,0 +1,6 @@
+appId: ${APP_ID}
+---
+- swipe:
+    start: 50%, 35%
+    end: 50%, 90%
+    duration: 500

--- a/.maestro/shared/create-pubky.yaml
+++ b/.maestro/shared/create-pubky.yaml
@@ -1,0 +1,14 @@
+appId: ${APP_ID}
+---
+- tapOn:
+    id: AddPubkyButton
+- assertVisible:
+    id: add-pubky-title
+- assertVisible:
+    id: AddPubkyManual
+- tapOn:
+    id: AddPubkyManual
+- assertVisible:
+    id: NewPubkyContinueButton
+- tapOn:
+    id: NewPubkyContinueButton

--- a/.maestro/shared/onboarding.yaml
+++ b/.maestro/shared/onboarding.yaml
@@ -1,13 +1,20 @@
 appId: ${APP_ID}
 ---
-- extendedWaitUntil:
-    visible:
-      id: TermsOfUseTitle
-    timeout: 60000
-- assertVisible: Terms of Use.
+- assertVisible:
+    id: TermsTitle
+- swipe:
+    start: 50%, 60%
+    end: 50%, 18%
+    duration: 700
+- swipe:
+    start: 50%, 60%
+    end: 50%, 18%
+    duration: 700
+- assertNotVisible:
+    id: TermsTitle
 - tapOn:
     id: TermsContinueButton
 - tapOn:
-    id: OnboardingGetStartedButton
+    id: OnboardingContinueButton
 - assertVisible:
     id: AddPubkyButton

--- a/.maestro/shared/open-link.yaml
+++ b/.maestro/shared/open-link.yaml
@@ -1,0 +1,8 @@
+appId: ${APP_ID}
+---
+- openLink: ${URL}
+- runFlow:
+    when:
+      visible: Open in.*Pubky Ring.*
+    commands:
+      - tapOn: Open

--- a/.maestro/shared/signup.yaml
+++ b/.maestro/shared/signup.yaml
@@ -1,26 +1,15 @@
 appId: ${APP_ID}
-name: create-pubky-custom-homeserver
 env:
   STAGING_HOMESERVER: ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy
   PUBKY_NAME: Staging Test Pubky
 ---
 - runScript: ../scripts/request-invite-code.js
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- runFlow: ../shared/start-new-pubky.yaml
-- tapOn:
-    id: HomeserverCustomOption
 - assertVisible:
-    id: HomeserverCustomRadioInner
-- assertNotVisible:
-    id: HomeserverDefaultRadioInner
+    id: PubkyBox--0-ActionButton
 - tapOn:
-    id: HomeserverContinueButton
-- extendedWaitUntil:
-    visible:
-      id: EditPubkyNameInput
-    timeout: 30000
+    id: PubkyBox--0-ActionButton
+- assertVisible:
+    id: EditPubkyNameInput
 - tapOn:
     id: EditPubkyNameInput
 - inputText: ${PUBKY_NAME}
@@ -29,14 +18,16 @@ env:
     id: EditPubkyInviteCodeInput
 - inputText: ${output.INVITE_CODE_WITHOUT_HYPHENS}
 - runFlow:
-    file: ../shared/clearInputText.yaml
+    file: clear-input-text.yaml
     env:
       INPUT_ID: EditPubkyHomeserverInput
 - setClipboard: ${STAGING_HOMESERVER}
 - pasteText
 - tapOn:
-    id: EditPubkyNameLabel # hide keyboard
+    id: EditPubkyHomeserverLabel
 - tapOn:
     id: EditPubkySaveButton
-- assertVisible:
-    id: PubkyBox-StagingTestPubky-0
+- extendedWaitUntil:
+    visible:
+      id: PubkyBox-StagingTestPubky-0
+    timeout: 120000

--- a/.maestro/shared/start-new-pubky.yaml
+++ b/.maestro/shared/start-new-pubky.yaml
@@ -1,8 +1,0 @@
-appId: ${APP_ID}
----
-- tapOn:
-    id: AddPubkyButton
-- tapOn:
-    id: NewPubkyButton
-- tapOn:
-    id: NewPubkyContinueButton

--- a/src/components/AddPubky.tsx
+++ b/src/components/AddPubky.tsx
@@ -185,13 +185,13 @@ const AddPubky = ({
 						onPress: () => onScanQrPress(i18n.t('home.scanQR')),
 					},
 					{
-						id: 'NewPubkyButton',
+						id: 'AddPubkyManual',
 						text: i18n.t('addPubky.newPubkyButton'),
 						icon: <Pencil />,
 						onPress: onCreatePubky,
 					},
 					{
-						id: 'ImportPubkyButton',
+						id: 'AddPubkyImport',
 						text: i18n.t('addPubky.importPubkyButton'),
 						icon: <Upload />,
 						onPress: onImportPubky,

--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -6,7 +6,12 @@ import { performAuth } from '../utils/pubky';
 import { useDispatch, useSelector } from 'react-redux';
 import { showToast, sleep } from '../utils/helpers.ts';
 import PubkyCard from './PubkyCard.tsx';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming, withSequence } from 'react-native-reanimated';
+import Animated, {
+	useAnimatedStyle,
+	useSharedValue,
+	withTiming,
+	withSequence,
+} from 'react-native-reanimated';
 import { copyToClipboard } from '../utils/clipboard.ts';
 import { BodySText, CaptionSBText, CaptionText } from '../theme/typography';
 import { RootState } from '../store';
@@ -186,7 +191,10 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 	return (
 		<Sheet id="confirm-auth" title={titleText} showBottomSafeAreaInset={false} headerRight={headerProgress}>
 			<View style={styles.section}>
-				<CaptionText style={styles.sectionTitle}>
+				<CaptionText
+					style={styles.sectionTitle}
+					testID={isAuthorized ? 'ConfirmAuthGrantedPermissions' : 'ConfirmAuthRequestedPermissions'}
+				>
 					{isAuthorized ? t('auth.grantedPermissions') : t('auth.requestedPermissions')}
 				</CaptionText>
 
@@ -218,6 +226,7 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 							<Button
 								text={authorizing ? t('common.close') : t('common.cancel')}
 								size="large"
+								testID="ConfirmAuthCancelButton"
 								onPress={handleDeny}
 							/>
 							<Button
@@ -225,11 +234,18 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 								size="large"
 								variant="secondary"
 								disabled={authorizing}
+								testID="ConfirmAuthAuthorizeButton"
 								onPress={handleAuth}
 							/>
 						</>
 					) : (
-						<Button text={t('common.ok')} size="large" variant="secondary" onPress={handleClose} />
+						<Button
+							text={t('common.ok')}
+							size="large"
+							variant="secondary"
+							testID="ConfirmAuthSuccessButton"
+							onPress={handleClose}
+						/>
 					)}
 				</View>
 

--- a/src/components/EditPubky.tsx
+++ b/src/components/EditPubky.tsx
@@ -382,7 +382,7 @@ const EditPubky = ({
 					</>
 				)}
 
-				<CaptionText>{i18n.t('editPubky.homeserver')}</CaptionText>
+				<CaptionText testID="EditPubkyHomeserverLabel">{i18n.t('editPubky.homeserver')}</CaptionText>
 				<InputItemComponent
 					testID="EditPubkyHomeserverInput"
 					value={homeServer}

--- a/src/components/MnemonicForm.tsx
+++ b/src/components/MnemonicForm.tsx
@@ -308,11 +308,6 @@ const MnemonicForm = ({ onCancel, onImport }: MnemonicFormProps): ReactElement =
 				}}
 				style={[styles.mnemonicInput, isInvalid && styles.invalidInput, loading && styles.disabledInput]}
 				value={getDisplayValue(index)}
-				onChangeText={text => updateMnemonicWord(index, text)}
-				onFocus={() => handleFocus(index)}
-				onBlur={() => handleBlur(index)}
-				onSubmitEditing={() => handleSubmitEditing(index)}
-				onKeyPress={handleKeyPress}
 				placeholder={`${index + 1}.`}
 				placeholderTextColor="rgba(255, 255, 255, 0.32)"
 				autoCapitalize="none"
@@ -325,6 +320,12 @@ const MnemonicForm = ({ onCancel, onImport }: MnemonicFormProps): ReactElement =
 				returnKeyType={index === 11 ? 'done' : 'next'}
 				submitBehavior="submit"
 				editable={!loading}
+				testID={`MnemonicWordInput-${index + 1}`}
+				onChangeText={text => updateMnemonicWord(index, text)}
+				onFocus={() => handleFocus(index)}
+				onBlur={() => handleBlur(index)}
+				onSubmitEditing={() => handleSubmitEditing(index)}
+				onKeyPress={handleKeyPress}
 			/>
 		);
 	};
@@ -371,13 +372,19 @@ const MnemonicForm = ({ onCancel, onImport }: MnemonicFormProps): ReactElement =
 				</View>
 
 				<View style={styles.buttonContainer}>
-					<Button text={i18n.t('common.cancel')} size="large" onPress={handleCancel} />
+					<Button
+						text={i18n.t('common.cancel')}
+						size="large"
+						testID="MnemonicCancelButton"
+						onPress={handleCancel}
+					/>
 					<Button
 						text={i18n.t('import.title')}
 						size="large"
 						variant="secondary"
 						loading={loading}
 						disabled={!enableImport}
+						testID="MnemonicImportButton"
 						onPress={handleImport}
 					/>
 				</View>

--- a/src/components/OnboardingContent.tsx
+++ b/src/components/OnboardingContent.tsx
@@ -41,7 +41,7 @@ const OnboardingContent = (): ReactElement => {
 					<Button
 						text={t('onboarding.getStarted')}
 						size="large"
-						testID="OnboardingGetStartedButton"
+						testID="OnboardingContinueButton"
 						onPress={navigateHome}
 					/>
 				</View>

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -111,6 +111,7 @@ const PubkyBox = ({
 			style={styles.container}
 			disabled={disabled}
 			activeOpacity={0.7}
+			accessible={pubkyData.signedUp}
 			testID={pubkyBoxTestID}
 			onPress={handleOnPress}
 			onLongPress={onLongPress}
@@ -140,6 +141,7 @@ const PubkyBox = ({
 					variant="secondary"
 					loading={isQRLoading || loading}
 					icon={pubkyData.signedUp ? <Scan size={24} /> : <></>}
+					testID={`${pubkyBoxTestID}-ActionButton`}
 					onPress={qrPress}
 					onLongPress={onLongPress}
 				/>

--- a/src/components/TermsOfUseContent.tsx
+++ b/src/components/TermsOfUseContent.tsx
@@ -8,7 +8,7 @@ const TermsOfUseContent = (): ReactElement => {
 
 	return (
 		<>
-			<DisplayText style={styles.title} testID="TermsOfUseTitle">
+			<DisplayText style={styles.title} testID="TermsTitle">
 				{t('terms.title')}
 			</DisplayText>
 			<View style={styles.subtitleContainer}>

--- a/src/screens/TermsOfUse.tsx
+++ b/src/screens/TermsOfUse.tsx
@@ -43,7 +43,7 @@ const TermsOfUse = (): React.ReactElement => {
 			</RadialGradient>
 
 			<View style={styles.contentContainer}>
-				<ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+				<ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false} testID="TermsScrollView">
 					<View style={styles.textContainer}>
 						<TermsOfUseContent />
 					</View>


### PR DESCRIPTION
## Summary

- Add Maestro flows for pubky authorization, mnemonic import, and key migration
- Extract shared Maestro setup for creating a pubky and signing up with the staging homeserver
- Update existing create-pubky flows to reuse shared setup helpers
- Add stable test IDs for auth, onboarding, terms, mnemonic import, Add Pubky, and edit homeserver interactions

