### PR TITLE
fix(auth): move Android auth countdown into sheet header

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "react-native-screens": "^4.24.0",
     "react-native-share": "^12.2.6",
     "react-native-svg": "^15.15.4",
-    "react-native-system-navigation-bar": "^2.8.0",
     "react-native-toast-message": "^2.3.3",
     "react-native-worklets": "^0.8.2",
     "react-redux": "^9.2.0",

--- a/src/components/CircularProgressBar.tsx
+++ b/src/components/CircularProgressBar.tsx
@@ -1,0 +1,102 @@
+import React, { memo, useEffect, useRef, useState } from 'react';
+import Svg, { Circle } from 'react-native-svg';
+
+type CircularProgressBarProps = {
+	duration?: number;
+	size?: number;
+	strokeWidth?: number;
+	unfilledColor?: string;
+	filledColor?: string;
+	drain?: boolean;
+	onComplete?: () => void;
+};
+
+const CircularProgressBar = ({
+	duration = 20000,
+	size = 24,
+	strokeWidth = 2,
+	unfilledColor = '#333333',
+	filledColor = '#FFFFFF',
+	drain = false,
+	onComplete,
+}: CircularProgressBarProps): React.ReactElement => {
+	const [progress, setProgress] = useState(drain ? 1 : 0);
+	const animationFrame = useRef<number | null>(null);
+	const completedOnce = useRef(false);
+	const onCompleteRef = useRef(onComplete);
+	const radius = (size - strokeWidth) / 2;
+	const center = size / 2;
+	const circumference = 2 * Math.PI * radius;
+	const strokeDashoffset = circumference * (1 - progress);
+
+	useEffect(() => {
+		onCompleteRef.current = onComplete;
+	}, [onComplete]);
+
+	useEffect(() => {
+		const startTime = Date.now();
+		const safeDuration = Math.max(duration, 1);
+
+		completedOnce.current = false;
+		setProgress(drain ? 1 : 0);
+
+		const updateProgress = (): void => {
+			const elapsed = Date.now() - startTime;
+			const nextProgress = Math.min(elapsed / safeDuration, 1);
+
+			setProgress(drain ? 1 - nextProgress : nextProgress);
+
+			if (nextProgress >= 1) {
+				if (onCompleteRef.current && !completedOnce.current) {
+					completedOnce.current = true;
+					onCompleteRef.current();
+				}
+				return;
+			}
+
+			animationFrame.current = requestAnimationFrame(updateProgress);
+		};
+
+		animationFrame.current = requestAnimationFrame(updateProgress);
+
+		return (): void => {
+			if (animationFrame.current !== null) {
+				cancelAnimationFrame(animationFrame.current);
+				animationFrame.current = null;
+			}
+		};
+	}, [duration, drain]);
+
+	return (
+		<Svg
+			width={size}
+			height={size}
+			viewBox={`0 0 ${size} ${size}`}
+			style={{ transform: [{ rotate: '-90deg' }] }}
+			accessibilityRole="progressbar"
+			accessibilityValue={{ min: 0, max: 1, now: undefined }}
+		>
+			<Circle
+				cx={center}
+				cy={center}
+				r={radius}
+				stroke={unfilledColor}
+				strokeWidth={strokeWidth}
+				fill="none"
+			/>
+			<Circle
+				cx={center}
+				cy={center}
+				r={radius}
+				stroke={filledColor}
+				strokeWidth={strokeWidth}
+				fill="none"
+				strokeLinecap="round"
+				strokeDasharray={`${circumference} ${circumference}`}
+				strokeDashoffset={strokeDashoffset}
+			/>
+		</Svg>
+	);
+};
+
+export default memo(CircularProgressBar);

--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -12,7 +12,6 @@ import { BodySText, CaptionSBText, CaptionText } from '../theme/typography';
 import { RootState } from '../store';
 import { getPubkyName } from '../store/selectors/pubkySelectors.ts';
 import ProgressBar from './ProgressBar.tsx';
-import SystemNavigationBar from 'react-native-system-navigation-bar';
 import { useTranslation } from 'react-i18next';
 import { XCallbackParams } from '../utils/inputParser.ts';
 import { openXSuccess, openXError, openXCancel } from '../utils/xCallback.ts';
@@ -20,6 +19,7 @@ import Button from './Button.tsx';
 import Sheet from './Sheet.tsx';
 import SafeAreaInset from './SafeAreaInset.tsx';
 import { CheckCircle, Folder } from '../icons/index.ts';
+import CircularProgressBar from './CircularProgressBar.tsx';
 
 interface ConfirmAuthProps {
 	pubky: string;
@@ -60,6 +60,7 @@ const Permission = memo(
 );
 
 const FADE_DURATION = 100;
+const CONFIRM_AUTH_TIMEOUT_MS = 60000;
 
 const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement => {
 	const { t } = useTranslation();
@@ -107,7 +108,6 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 
 	const handleClose = useCallback(() => {
 		SheetManager.hide('confirm-auth');
-		SystemNavigationBar.navigationShow();
 	}, []);
 
 	const handleDeny = useCallback(() => {
@@ -133,7 +133,6 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 				return;
 			}
 			setIsAuthorized(true);
-			SystemNavigationBar.navigationShow();
 			onComplete?.();
 			if (xCallback?.xSuccess) {
 				await sleep(FADE_DURATION + 300);
@@ -174,8 +173,18 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 			? t('auth.authorizeForApp', { appName: xCallback.xSource })
 			: t('auth.authorize');
 
+	const headerProgress =
+		Platform.OS === 'android' && !isAuthorized ? (
+			<CircularProgressBar
+				duration={CONFIRM_AUTH_TIMEOUT_MS}
+				size={20}
+				drain={true}
+				onComplete={handleDeny}
+			/>
+		) : undefined;
+
 	return (
-		<Sheet id="confirm-auth" title={titleText} showBottomSafeAreaInset={false}>
+		<Sheet id="confirm-auth" title={titleText} showBottomSafeAreaInset={false} headerRight={headerProgress}>
 			<View style={styles.section}>
 				<CaptionText style={styles.sectionTitle}>
 					{isAuthorized ? t('auth.grantedPermissions') : t('auth.requestedPermissions')}
@@ -226,12 +235,10 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 
 				<SafeAreaInset edge="bottom" />
 
-				{!isAuthorized && (
+				{Platform.OS === 'ios' && !isAuthorized && (
 					<ProgressBar
 						style={styles.progressBarContainer}
-						duration={60000}
-						//fadeIn={true}
-						//fadeInDuration={1000}
+						duration={CONFIRM_AUTH_TIMEOUT_MS}
 						unfilledColor="#333333"
 						height={5}
 						drain={true}
@@ -306,10 +313,9 @@ const styles = StyleSheet.create({
 	},
 	progressBarContainer: {
 		position: 'absolute',
-		bottom: 0,
+		bottom: 8,
 		width: 143,
 		alignSelf: 'center',
-		marginBottom: Platform.select({ ios: 8, android: 0 }),
 	},
 });
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -73,7 +73,7 @@ const ProgressBar = ({
 	}, [delayRender]);
 
 	useEffect(() => {
-		if (!shouldRender) return;
+		if (!shouldRender || dimensions.width === 0) return;
 
 		// restart animation whenever duration or delay changes
 		completedOnce.current = false;
@@ -106,7 +106,7 @@ const ProgressBar = ({
 			cancelAnimation(opacity);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [shouldRender, duration, delayStart, fadeIn, fadeInDuration, drain, onComplete]);
+	}, [shouldRender, dimensions.width, duration, delayStart, fadeIn, fadeInDuration, drain, onComplete]);
 
 	if (!shouldRender) {
 		return (

--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -26,6 +26,7 @@ interface SheetProps {
 	contentStyle?: StyleProp<ViewStyle>;
 	keyboardHandlerEnabled?: boolean;
 	showBottomSafeAreaInset?: boolean;
+	headerRight?: ReactNode;
 	onBackPress?: () => void;
 	onClose?: () => void;
 }
@@ -48,6 +49,7 @@ const Sheet = ({
 	contentStyle,
 	keyboardHandlerEnabled = Platform.OS === 'ios',
 	showBottomSafeAreaInset = true,
+	headerRight,
 	onBackPress,
 	onClose,
 }: SheetProps): ReactElement => {
@@ -96,7 +98,7 @@ const Sheet = ({
 
 					<BodyMBText testID={`${id}-title`}>{title}</BodyMBText>
 
-					<HeaderNavButton style={styles.navButton} />
+					<View style={styles.navButton}>{headerRight}</View>
 				</View>
 
 				<View style={[styles.content, contentStyle]}>{children}</View>

--- a/src/utils/actions/authAction.ts
+++ b/src/utils/actions/authAction.ts
@@ -8,7 +8,6 @@
 import { Result, ok, err } from '@synonymdev/result';
 import { parseAuthUrl, PubkyAuthDetails } from '@synonymdev/react-native-pubky';
 import { SheetManager } from 'react-native-actions-sheet';
-import SystemNavigationBar from 'react-native-system-navigation-bar';
 import { InputAction, AuthParams, XCallbackParams } from '../inputParser';
 import { ActionContext } from '../inputRouter';
 import { performAuth } from '../pubky';
@@ -136,8 +135,6 @@ const showAuthConfirmation = async ({
 	xCallback?: XCallbackParams;
 }): Promise<Result<string>> => {
 	try {
-		SystemNavigationBar.navigationHide().then();
-
 		// Small timeout allows the sheet time to properly display
 		setTimeout(() => {
 			SheetManager.show('confirm-auth', {
@@ -147,9 +144,6 @@ const showAuthConfirmation = async ({
 					authDetails,
 					xCallback,
 					onComplete: async (): Promise<void> => {},
-				},
-				onClose: () => {
-					SystemNavigationBar.navigationShow().then();
 				},
 			});
 		}, AUTH_SHEET_DELAY);
@@ -163,7 +157,6 @@ const showAuthConfirmation = async ({
 			description,
 		});
 		console.log(`${description}:`, error);
-		SystemNavigationBar.navigationShow().then();
 		return err(description);
 	}
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9465,11 +9465,6 @@ react-native-svg@^15.15.4:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
-react-native-system-navigation-bar@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/react-native-system-navigation-bar/-/react-native-system-navigation-bar-2.8.0.tgz#68b0359121fc08751436a01e44639cb3b39bdad8"
-  integrity sha512-VaBdTAUCnKfngphHJxZn/Axs6pzANYOr3UQDb9+iOzwqN6br43S4yFtqnnH85WPSMa+4aiOdm0AivG9e0tPUnA==
-
 react-native-toast-message@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/react-native-toast-message/-/react-native-toast-message-2.3.3.tgz#e301508d386a9902ff6b4559ecc6674f8cfdf97a"


### PR DESCRIPTION
## Summary

- Add a reusable `CircularProgressBar` component for compact countdown UI
- Show the auth countdown as a circular progress indicator in the Android sheet header
- Remove the `react-native-system-navigation-bar` dependency and auth flow calls

<img width="400" alt="Screenshot_1780668076" src="https://github.com/user-attachments/assets/13190061-d969-4286-9650-cfb1c634dd02" />
