### PR TITLE
chore: split apk

### DIFF
--- a/.github/scripts/android-e2e.sh
+++ b/.github/scripts/android-e2e.sh
@@ -5,7 +5,12 @@ trap 'adb logcat -d > "$GITHUB_WORKSPACE/android-logcat.txt" || true' EXIT
 
 cd "$GITHUB_WORKSPACE/android"
 ./gradlew :app:assembleRelease -PreactNativeArchitectures=x86_64 --no-daemon
-adb install -r app/build/outputs/apk/release/app-release.apk
+APK_PATH="$(find app/build/outputs/apk/release -maxdepth 1 -name '*.apk' -print -quit)"
+if [[ -z "$APK_PATH" ]]; then
+  echo "No release APK found in app/build/outputs/apk/release" >&2
+  exit 1
+fi
+adb install -r "$APK_PATH"
 
 cd "$GITHUB_WORKSPACE"
 bash .maestro/scripts/prepare-device-motion.sh android

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -76,7 +76,7 @@ jobs:
       if: always()
       with:
         name: android-release-apk
-        path: android/app/build/outputs/apk/release/app-release.apk
+        path: android/app/build/outputs/apk/release/*.apk
         if-no-files-found: ignore
         retention-days: 7
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you can't get this to work, see the [Troubleshooting](https://reactnative.dev
 
 # 🔐 Verifying Releases
 
-Ensure your `app-release.apk` is authentic and untampered by verifying its **GPG signature** and **SHA256 checksum**.
+Ensure the APK you downloaded is authentic and untampered by verifying its **GPG signature** and **SHA256 checksum**. Android releases may include a universal APK (for example, `app-universal-release.apk`) and/or ABI-specific APKs (for example, `app-arm64-v8a-release.apk`).
 
 ### 1. Import the Maintainer's GPG Key
 
@@ -112,7 +112,7 @@ gpg --import public-key.asc
 ### 2. Verify the APK Signature
 
 ```bash
-gpg --verify app-release.apk.asc app-release.apk
+gpg --verify <apk-file>.asc <apk-file>
 ```
 
 ### 3. Verify the Checksum

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,6 +59,13 @@ react {
  */
 def enableProguardInReleaseBuilds = false
 
+def enableSeparateBuildPerCPUArchitecture = true
+
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "arm64-v8a"]
+}
+
 /**
  * The preferred build flavor of JavaScriptCore (JSC)
  *
@@ -83,6 +90,15 @@ android {
     // (mmap) at startup instead of decompressed into memory, improving TTI.
     androidResources {
         noCompress += ['bundle']
+    }
+
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk true
+            include (*reactNativeArchitectures())
+        }
     }
 
     defaultConfig {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,10 +22,13 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-# Use this property to specify which architecture you want to build.
+# Use this property to specify which architectures you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+#
+# Keep release APKs ARM-only by default. Use x86_64 explicitly for emulator
+# builds on x86 CI hosts.
+reactNativeArchitectures=armeabi-v7a,arm64-v8a
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@adrianso/react-native-device-brightness": "^1.2.7",
     "@dr.pogodin/react-native-fs": "^2.37.0",
-    "@react-native-async-storage/async-storage": "^3.0.2",
     "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/blur": "^4.4.1",
     "@react-native-community/netinfo": "^12.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,13 +1583,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@react-native-async-storage/async-storage@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-3.0.2.tgz#caf2d0d7038dc2b8a2a48971bdbd047db0a2ac86"
-  integrity sha512-XP0zDIl+1XoeuQ7f878qXKdl77zLwzLALPpxvNRc7ZtDh9ew36WSvOdQOhFkexMySapFAWxEbZxS8K8J2DU4eg==
-  dependencies:
-    idb "8.0.3"
-
 "@react-native-clipboard/clipboard@^1.16.3":
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.16.3.tgz#7807a90fd9984bf4d3a96faf2eee20457984a9bd"
@@ -4555,11 +4548,6 @@ iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
-
-idb@8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/idb/-/idb-8.0.3.tgz#c91e558f15a8d53f1d7f53a094d226fc3ad71fd9"
-  integrity sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==
 
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Summary

Reduce release APK size by avoiding packaging native libraries for every supported ABI into a single universal APK and removing unused dependencies. Users using GitHub releases should see the download size go from 180MB to about 60MB.

- Add Android ABI split configuration for release APKs
- Default Android builds to ARM-only architectures: `armeabi-v7a` and `arm64-v8a`
- Keep Android e2e CI working on `x86_64` by using the existing `reactNativeArchitectures` override
- Update e2e APK install/upload paths to handle split APK filenames
- Remove unused dependency `@react-native-async-storage/async-storage`