### PR TITLE
fix: delete pubky

### DIFF
--- a/.maestro/flows/delete-pubky.yaml
+++ b/.maestro/flows/delete-pubky.yaml
@@ -1,0 +1,24 @@
+appId: ${APP_ID}
+name: delete-pubky
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow: ../shared/create-pubky.yaml
+- runFlow: ../shared/close-sheet.yaml
+- extendedWaitUntil:
+    visible: 'pubky #1'
+    timeout: 30000
+- tapOn:
+    text: 'pubky #1'
+- assertVisible:
+    id: PubkyDetailDeleteButton
+- tapOn:
+    id: PubkyDetailDeleteButton
+- assertVisible:
+    id: delete-pubky-title
+- tapOn:
+    id: DeletePubkyConfirmButton
+- assertVisible:
+    id: AddPubkyButton
+- assertNotVisible: 'pubky #1'

--- a/src/components/DeletePubky.tsx
+++ b/src/components/DeletePubky.tsx
@@ -36,8 +36,19 @@ const DeletePubky = ({
 				<Image source={require('../images/trash.png')} style={styles.image} />
 			</View>
 			<View style={styles.buttonContainer}>
-				<Button text={t('common.cancel')} size="large" onPress={closeSheet} />
-				<Button text={t('common.delete')} size="large" variant="secondary" onPress={onDelete} />
+				<Button
+					text={t('common.cancel')}
+					size="large"
+					testID="DeletePubkyCancelButton"
+					onPress={closeSheet}
+				/>
+				<Button
+					text={t('common.delete')}
+					size="large"
+					variant="secondary"
+					testID="DeletePubkyConfirmButton"
+					onPress={onDelete}
+				/>
 			</View>
 		</Sheet>
 	);

--- a/src/components/PubkyDetail/PubkyDetail.tsx
+++ b/src/components/PubkyDetail/PubkyDetail.tsx
@@ -1,13 +1,12 @@
 import React, { memo, ReactElement, useCallback } from 'react';
 import { ScrollView, StyleSheet } from 'react-native';
-import { deletePubky, signOutOfHomeserver } from '../../utils/pubky.ts';
+import { signOutOfHomeserver } from '../../utils/pubky.ts';
 import { useDispatch } from 'react-redux';
 import PubkyDetailCard from './PubkyDetailCard';
 import { PubkyData } from '../../navigation/types.ts';
 import { showToast } from '../../utils/helpers.ts';
 import { showBackupPrompt } from '../../utils/sheetHelpers.ts';
 import { SheetManager } from 'react-native-actions-sheet';
-import { useTypedNavigation } from '../../navigation/hooks';
 import i18n from '../../i18n';
 import { HEADER_HEIGHT } from '../AppHeader.tsx';
 
@@ -15,27 +14,13 @@ export interface PubkyDetailProps {
 	index: number;
 	pubkyData: PubkyData;
 	onQRPress: () => Promise<void>;
+	onDelete: () => Promise<void>;
 }
 
-export const PubkyDetail = ({ index, pubkyData, onQRPress }: PubkyDetailProps): ReactElement => {
+export const PubkyDetail = ({ index, pubkyData, onQRPress, onDelete }: PubkyDetailProps): ReactElement => {
 	const { pubky, sessions } = pubkyData;
 	const publicKey = pubky.startsWith('pk:') ? pubky.slice(3) : pubky;
 	const dispatch = useDispatch();
-	const navigation = useTypedNavigation();
-
-	const onDelete = useCallback(async () => {
-		const deleteRes = await deletePubky(pubky, dispatch);
-		if (deleteRes.isErr()) {
-			showToast({
-				type: 'error',
-				title: i18n.t('pubkyErrors.failedToDelete'),
-				description: i18n.t('pubkyErrors.deleteError'),
-			});
-			return;
-		}
-		SheetManager.hide('delete-pubky').then();
-		navigation.goBack();
-	}, [dispatch, navigation, pubky]);
 
 	const onSignOut = useCallback(
 		(sessionSecret: string) => {

--- a/src/components/PubkyDetail/PubkyDetailCard.tsx
+++ b/src/components/PubkyDetail/PubkyDetailCard.tsx
@@ -70,18 +70,21 @@ export const PubkyDetailCard = memo(
 						style={styles.actionButton}
 						text={t('common.share')}
 						icon={shareIcon}
+						testID="PubkyDetailShareButton"
 						onPress={onSharePress}
 					/>
 					<Button
 						style={styles.actionButton}
 						text={t('backup.backup')}
 						icon={backupIcon}
+						testID="PubkyDetailBackupButton"
 						onPress={onBackup}
 					/>
 					<Button
 						style={styles.actionButton}
 						text={t('common.delete')}
 						icon={deleteIcon}
+						testID="PubkyDetailDeleteButton"
 						onPress={onDelete}
 					/>
 				</View>

--- a/src/screens/PubkyDetailScreen.tsx
+++ b/src/screens/PubkyDetailScreen.tsx
@@ -1,31 +1,38 @@
 import React, { memo, ReactElement, useCallback, useMemo } from 'react';
+import { SheetManager } from 'react-native-actions-sheet';
+import { useTranslation } from 'react-i18next';
 import { PubkyData } from '../navigation/types';
 import PubkyDetail from '../components/PubkyDetail/PubkyDetail.tsx';
-import { useSelector } from 'react-redux';
-import { getPubky } from '../store/selectors/pubkySelectors.ts';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../store';
+import { getPubky } from '../store/selectors/pubkySelectors.ts';
 import AppHeader from '../components/AppHeader.tsx';
 import HeaderNavButton from '../components/HeaderNavButton.tsx';
-import { useTypedRoute } from '../navigation/hooks';
+import { useTypedNavigation, useTypedRoute } from '../navigation/hooks';
 import { showEditPubkySheet } from '../utils/sheetHelpers.ts';
 import { useInputHandler } from '../hooks/useInputHandler';
-import i18n from '../i18n';
 import SafeAreaView from '../components/SafeAreaView.tsx';
 import { Pencil } from '../icons/index.ts';
+import { deletePubky } from '../utils/pubky.ts';
+import { showToast } from '../utils/helpers.ts';
 
 const PubkyDetailScreen = (): ReactElement => {
+	const { t } = useTranslation();
 	const route = useTypedRoute<'PubkyDetail'>();
+	const navigation = useTypedNavigation();
+	const dispatch = useDispatch();
 	const { pubky, index } = route.params;
 	const data = useSelector((state: RootState) => getPubky(state, pubky));
 	const { showScanner } = useInputHandler({ pubky });
 
-	const pubkyData: PubkyData = useMemo(() => {
+	const pubkyData = useMemo<PubkyData | undefined>(() => {
+		if (!data) return undefined;
 		return { ...data, pubky };
 	}, [data, pubky]);
 
 	const onRightButtonPress = useCallback(() => {
 		showEditPubkySheet({
-			title: data.signedUp ? i18n.t('common.edit') : i18n.t('pubky.setup'),
+			title: data.signedUp ? t('common.edit') : t('pubky.setup'),
 			pubky,
 		});
 	}, [data, pubky]);
@@ -34,16 +41,35 @@ const PubkyDetailScreen = (): ReactElement => {
 		return showScanner({ pubky });
 	}, [showScanner, pubky]);
 
+	const handleDelete = useCallback(async () => {
+		const deleteRes = await deletePubky(pubky, dispatch);
+		if (deleteRes.isErr()) {
+			showToast({
+				type: 'error',
+				title: t('pubkyErrors.failedToDelete'),
+				description: t('pubkyErrors.deleteError'),
+			});
+			return;
+		}
+
+		await SheetManager.hide('delete-pubky');
+		navigation.goBack();
+	}, [dispatch, navigation, pubky]);
+
 	const rightButton = (
 		<HeaderNavButton onPressIn={onRightButtonPress}>
 			<Pencil size={24} />
 		</HeaderNavButton>
 	);
 
+	if (!pubkyData) {
+		return <SafeAreaView edges={['bottom']} />;
+	}
+
 	return (
 		<SafeAreaView edges={['bottom']}>
 			<AppHeader rightButton={rightButton} />
-			<PubkyDetail index={index} pubkyData={pubkyData} onQRPress={handleQRPress} />
+			<PubkyDetail index={index} pubkyData={pubkyData} onQRPress={handleQRPress} onDelete={handleDelete} />
 		</SafeAreaView>
 	);
 };

--- a/src/store/selectors/pubkySelectors.ts
+++ b/src/store/selectors/pubkySelectors.ts
@@ -4,7 +4,12 @@ import { RootState } from '../../types';
 import { truncateStr } from '../../utils/pubky.ts';
 
 /**
- * Get a specific pubky by its identifier
+ * Get a specific pubky by its identifier.
+ *
+ * The state map is typed as `{ [key: string]: Pubky }`, so this selector also
+ * returns `Pubky`. At runtime, a lookup for a missing or recently deleted pubky
+ * can still return `undefined`. Callers should only use this when the pubky is
+ * expected to exist, or handle the missing case explicitly at the call site.
  */
 export const getPubky = (state: RootState, pubky: string): Pubky => {
 	return state.pubky.pubkys[pubky];


### PR DESCRIPTION
## Summary

Fixes a crash when deleting a pubky from the detail screen.

The detail route can remain mounted briefly after the pubky is removed from Redux, so the screen now handles that missing state locally while deletion/navigation are owned by the screen.

## Changes

- Move delete handling from `PubkyDetail` into `PubkyDetailScreen`
- Keep `PubkyDetail` focused on rendering and forwarding callbacks
- Avoid rendering detail content if the route’s pubky has already been removed
- Document that `getPubky` assumes the pubky exists, even though missing keys may be `undefined` at runtime
- Add E2E case for the deletion flow