### PR TITLE
fix: improve errors

### DIFF
--- a/.maestro/flows/create-pubky-and-authorize.yaml
+++ b/.maestro/flows/create-pubky-and-authorize.yaml
@@ -1,7 +1,7 @@
 appId: ${APP_ID}
 name: create-pubky-and-authorize
 env:
-  AUTH_URL: pubkyring://signin?relay=https%3A%2F%2Frelay.staging.pubky.app&secret=maestro-auth-secret&caps=%2Fpub%2Fpubky.app%2F%3Arw&x-source=Maestro
+  AUTH_URL: pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://httprelay.staging.pubky.app/inbox&secret=okIbCVEBmJJGU56jO4WPmeghdyLNun6VOp_xV-B5Yx0
 ---
 - launchApp:
     clearState: true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "^2.3.1",
     "@shopify/react-native-skia": "^2.6.2",
-    "@synonymdev/react-native-pubky": "0.11.3",
+    "@synonymdev/react-native-pubky": "0.11.4",
     "@synonymdev/result": "^0.0.2",
     "bip39": "^3.1.0",
     "buffer": "^6.0.3",

--- a/src/components/EditPubky.tsx
+++ b/src/components/EditPubky.tsx
@@ -1,5 +1,6 @@
 import React, { memo, ReactElement, useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { StyleSheet, Keyboard, TextInput as NativeTextInput, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { TextInput } from '../theme/components.ts';
 import Button from '../components/Button.tsx';
 import { getPubkySecretKey, signInToHomeserver, signUpToHomeserver, truncatePubky } from '../utils/pubky.ts';
@@ -11,9 +12,9 @@ import { err } from '@synonymdev/result';
 import { DEFAULT_HOMESERVER, STAGING_HOMESERVER } from '../utils/constants.ts';
 import { getPubky } from '../store/selectors/pubkySelectors.ts';
 import { RootState } from '../types';
-import i18n from '../i18n';
 import { BodySText, CaptionText } from '../theme/typography';
 import Sheet from './Sheet.tsx';
+import { getSignupTokenErrorDescription } from '../utils/signupErrors.ts';
 
 const MAX_NAME_LENGTH = 50;
 
@@ -75,6 +76,7 @@ const EditPubky = ({
 		pubky: string;
 	};
 }): ReactElement => {
+	const { t } = useTranslation();
 	const { pubky } = useMemo(() => payload, [payload]);
 	const storedPubkyData = useSelector((state: RootState) => getPubky(state, pubky));
 	const [loading, setLoading] = useState(false);
@@ -163,6 +165,9 @@ const EditPubky = ({
 						dispatch,
 					});
 					if (signupRes.isErr()) {
+						const signupErrorMessage =
+							getSignupTokenErrorDescription(signupRes.error.message) ?? t('editPubkySheet.unableToSignUp');
+
 						// The pubky might be an import that can successfully login.
 						if (!storedPubkyData.homeserver || storedPubkyData.homeserver === homeServer.trim()) {
 							// Attempt sign-in
@@ -174,13 +179,13 @@ const EditPubky = ({
 							});
 							if (signinRes.isErr()) {
 								updateName(); // No need to prevent updating the name if we can.
-								setError(i18n.t('editPubkySheet.unableToSignUp'));
+								setError(signupErrorMessage);
 								return;
 							}
 							signedIn = true;
 						} else {
 							updateName(); // No need to prevent updating the name if we can.
-							setError(i18n.t('editPubkySheet.unableToSignUp'));
+							setError(signupErrorMessage);
 							return;
 						}
 					}
@@ -199,7 +204,7 @@ const EditPubky = ({
 					});
 					if (signinRes.isErr()) {
 						updateName(); // No need to prevent updating the name if we can.
-						setError(i18n.t('editPubkySheet.unableToSignIn', { error: signinRes.error.message }));
+						setError(t('editPubkySheet.unableToSignIn', { error: signinRes.error.message }));
 						return;
 					}
 				}
@@ -227,6 +232,7 @@ const EditPubky = ({
 		dispatch,
 		updateName,
 		onClose,
+		t,
 	]);
 
 	const handleChangeText = useCallback((text: string) => {
@@ -333,10 +339,10 @@ const EditPubky = ({
 
 	const leftButtonText = useMemo(() => {
 		if (storedPubkyData.homeserver && haveFieldsChanged) {
-			return loading ? i18n.t('common.close') : i18n.t('editPubkySheet.reset');
+			return loading ? t('common.close') : t('editPubkySheet.reset');
 		}
-		return i18n.t('common.close');
-	}, [storedPubkyData.homeserver, haveFieldsChanged, loading]);
+		return t('common.close');
+	}, [storedPubkyData.homeserver, haveFieldsChanged, loading, t]);
 
 	const leftButtonOnPress = useCallback(() => {
 		if (storedPubkyData.homeserver && haveFieldsChanged) {
@@ -348,12 +354,12 @@ const EditPubky = ({
 	return (
 		<Sheet id="edit-pubky" title={title} keyboardHandlerEnabled={false}>
 			<ActionSheetScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
-				<CaptionText testID="EditPubkyNameLabel">{i18n.t('editPubkySheet.pubkyNameLabel')}</CaptionText>
+				<CaptionText testID="EditPubkyNameLabel">{t('editPubkySheet.pubkyNameLabel')}</CaptionText>
 				<InputItemComponent
 					testID="EditPubkyNameInput"
 					value={newPubkyName}
 					onChangeText={handleChangeText}
-					placeholder={i18n.t('editPubkySheet.pubkyNamePlaceholder')}
+					placeholder={t('editPubkySheet.pubkyNamePlaceholder')}
 					error={nameError}
 					autoFocus={true}
 					onSubmitEditing={handleNameSubmit}
@@ -361,13 +367,13 @@ const EditPubky = ({
 
 				{isSignupTokenInputVisible && (
 					<>
-						<CaptionText>{i18n.t('editPubkySheet.inviteCodeOptional')}</CaptionText>
+						<CaptionText>{t('editPubkySheet.inviteCodeOptional')}</CaptionText>
 						<InputItemComponent
 							testID="EditPubkyInviteCodeInput"
 							inputRef={signupTokenInputRef}
 							value={signupToken}
 							onChangeText={handleSignupTokenChange}
-							placeholder={i18n.t('editPubkySheet.inviteCodePlaceholder')}
+							placeholder={t('editPubkySheet.inviteCodePlaceholder')}
 							error=""
 							autoFocus={false}
 							onSubmitEditing={() => {
@@ -382,12 +388,12 @@ const EditPubky = ({
 					</>
 				)}
 
-				<CaptionText testID="EditPubkyHomeserverLabel">{i18n.t('editPubky.homeserver')}</CaptionText>
+				<CaptionText testID="EditPubkyHomeserverLabel">{t('editPubky.homeserver')}</CaptionText>
 				<InputItemComponent
 					testID="EditPubkyHomeserverInput"
 					value={homeServer}
 					onChangeText={setHomeServer}
-					placeholder={i18n.t('editPubky.homeserver')}
+					placeholder={t('editPubky.homeserver')}
 					error=""
 					autoFocus={false}
 					onSubmitEditing={handleHomeserverSubmit}
@@ -405,7 +411,7 @@ const EditPubky = ({
 			<View style={styles.buttonContainer}>
 				<Button text={leftButtonText} size="large" testID="EditPubkyLeftButton" onPress={leftButtonOnPress} />
 				<Button
-					text={i18n.t('common.save')}
+					text={t('common.save')}
 					size="large"
 					variant="secondary"
 					loading={loading}

--- a/src/components/LoadingModal.tsx
+++ b/src/components/LoadingModal.tsx
@@ -63,6 +63,8 @@ const LoadingModal = ({ payload }: { payload?: LoadingModalPayload }): ReactElem
 	// Get error state from Redux
 	const isError = loadingModalState.isError;
 	const errorMessage = loadingModalState.errorMessage;
+	const errorModalTitle = loadingModalState.errorModalTitle;
+	const errorDescription = loadingModalState.errorDescription;
 
 	// Reset loading modal state when component unmounts
 	useEffect(() => {
@@ -142,12 +144,16 @@ const LoadingModal = ({ payload }: { payload?: LoadingModalPayload }): ReactElem
 	}));
 
 	const baseError = t('loading.errorDescription');
-	const modalTitle = isError ? t('loading.errorModalTitle') : (payloadModalTitle ?? t('loading.modalTitle'));
+	const modalTitle = isError
+		? (errorModalTitle ?? t('loading.errorModalTitle'))
+		: (payloadModalTitle ?? t('loading.modalTitle'));
 	const title = isError ? null : (payloadTitle ?? t('loading.title'));
 	const description = isError
-		? errorMessage
-			? `${baseError} ${errorMessage}`
-			: baseError
+		? errorDescription
+			? errorDescription
+			: errorMessage
+				? `${baseError} ${errorMessage}`
+				: baseError
 		: (payloadDescription ?? t('loading.description'));
 	const waitText = payloadWaitText ?? t('loading.pleaseWait');
 

--- a/src/components/PubkySetup/InviteCode.tsx
+++ b/src/components/PubkySetup/InviteCode.tsx
@@ -16,6 +16,7 @@ import Button from '../Button.tsx';
 import { CheckCircle, Gift } from '../../icons/index.ts';
 import { accentColors } from '../../theme/index.ts';
 import { TextInput } from '../../theme/components.ts';
+import { getSignupTokenErrorDescription } from '../../utils/signupErrors.ts';
 
 const InviteCode = ({
 	payload,
@@ -101,6 +102,9 @@ const InviteCode = ({
 					dispatch,
 				});
 				if (signupRes.isErr()) {
+					const signupErrorMessage =
+						getSignupTokenErrorDescription(signupRes.error.message) ?? i18n.t('pubkyErrors.invalidInviteCode');
+
 					// The pubky might be an import that can successfully login.
 					if (!storedPubkyData?.homeserver || storedPubkyData.homeserver === homeserver) {
 						// Attempt sign-in
@@ -111,12 +115,12 @@ const InviteCode = ({
 							dispatch,
 						});
 						if (signinRes.isErr()) {
-							setError(i18n.t('pubkyErrors.invalidInviteCode'));
+							setError(signupErrorMessage);
 							return;
 						}
 						signedIn = true;
 					} else {
-						setError(i18n.t('pubkyErrors.invalidInviteCode'));
+						setError(signupErrorMessage);
 						return;
 					}
 				}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -350,7 +350,11 @@
 		"failedToGenerateKeypair": "Failed to generate keypair",
 		"signupSuccessful": "Signup Successful",
 		"newPubkyCreated": "Your new Pubky has been created",
-		"failedToProcessSignup": "Failed to process signup"
+		"failedToProcessSignup": "Failed to process signup",
+		"invalidTitle": "Invite Code Invalid",
+		"invalidDescription": "Your new pubky could not be configured, because the invite code is not valid.",
+		"requiredDescription": "An invite code is required to use this homeserver.",
+		"alreadyUsedDescription": "Your new pubky could not be configured, because this invite code has already been used."
 	},
 	"invite": {
 		"unknownErrorProcessing": "Unknown error processing invite"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -352,7 +352,11 @@
 		"failedToGenerateKeypair": "Fallo al generar el par de claves",
 		"signupSuccessful": "Inscripción realizada con éxito",
 		"newPubkyCreated": "Su nuevo Pubky ha sido creado",
-		"failedToProcessSignup": "No se ha podido procesar la inscripción"
+		"failedToProcessSignup": "No se ha podido procesar la inscripción",
+		"invalidTitle": "Código de invitación no válido",
+		"invalidDescription": "Su nuevo pubky no se pudo configurar porque el código de invitación no es válido.",
+		"requiredDescription": "Se requiere un código de invitación para usar este homeserver.",
+		"alreadyUsedDescription": "Su nuevo pubky no se pudo configurar porque este código de invitación ya se ha usado."
 	},
 	"invite": {
 		"unknownErrorProcessing": "Unknown error processing invite"

--- a/src/store/shapes/ui.ts
+++ b/src/store/shapes/ui.ts
@@ -3,6 +3,8 @@ import { Dispatch } from 'redux';
 export interface LoadingModalState {
 	isError: boolean;
 	errorMessage: string;
+	errorModalTitle?: string;
+	errorDescription?: string;
 	onTryAgain: (() => void) | null;
 }
 
@@ -13,6 +15,8 @@ export interface UIState {
 export const initialLoadingModalState: LoadingModalState = {
 	isError: false,
 	errorMessage: '',
+	errorModalTitle: undefined,
+	errorDescription: undefined,
 	onTryAgain: null,
 };
 

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -10,14 +10,20 @@ const uiSlice = createSlice({
 			action: PayloadAction<{
 				isError: boolean;
 				errorMessage?: string;
+				errorModalTitle?: string;
+				errorDescription?: string;
 			}>,
 		) => {
 			state.loadingModal.isError = action.payload.isError;
 			state.loadingModal.errorMessage = action.payload.errorMessage ?? '';
+			state.loadingModal.errorModalTitle = action.payload.errorModalTitle;
+			state.loadingModal.errorDescription = action.payload.errorDescription;
 		},
 		resetLoadingModal: state => {
 			state.loadingModal.isError = false;
 			state.loadingModal.errorMessage = '';
+			state.loadingModal.errorModalTitle = undefined;
+			state.loadingModal.errorDescription = undefined;
 		},
 	},
 });

--- a/src/utils/actions/inviteAction.ts
+++ b/src/utils/actions/inviteAction.ts
@@ -20,6 +20,7 @@ import { setLoadingModalError } from '../../store/slices/uiSlice';
 import { setStoredDispatch } from '../../store/shapes/ui';
 import i18n from '../../i18n';
 import { Dispatch } from 'redux';
+import { getSignupTokenErrorModalFields, LoadingErrorModalFields } from '../signupErrors';
 
 type InviteActionData = {
 	action: InputAction.Invite;
@@ -55,13 +56,18 @@ export const openCameraForRetry = (dispatch: Dispatch): void => {
 /**
  * Transitions the loading modal to error state via Redux
  */
-const showErrorState = (errorMessage: string, dispatch: Dispatch): void => {
+const showErrorState = (
+	errorMessage: string,
+	dispatch: Dispatch,
+	fields: LoadingErrorModalFields = {},
+): void => {
 	// Store dispatch for use in "Try again" button
 	setStoredDispatch(dispatch);
 	// Update Redux state to show error
 	dispatch(
 		setLoadingModalError({
 			isError: true,
+			...fields,
 			errorMessage: errorMessage,
 		}),
 	);
@@ -93,7 +99,7 @@ export const handleInviteAction = async (
 
 		if (createRes.isErr()) {
 			const errorMessage = getErrorMessage(createRes.error, i18n.t('errors.failedToCreatePubkyWithInvite'));
-			showErrorState(errorMessage, dispatch);
+			showErrorState(errorMessage, dispatch, getSignupTokenErrorModalFields(errorMessage));
 			await openXError(xCallback, 'INVITE_FAILED', errorMessage);
 			return err(errorMessage);
 		}

--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -19,6 +19,7 @@ import { setStoredDispatch } from '../../store/shapes/ui';
 import { EBackupPreference } from '../../types/pubky';
 import { handleAuthAction } from './authAction';
 import { SHEET_ANIMATION_DELAY } from '../constants.ts';
+import { getSignupTokenErrorModalFields, LoadingErrorModalFields } from '../signupErrors';
 import i18n from '../../i18n';
 import { SheetManager } from 'react-native-actions-sheet';
 import { Dispatch } from 'redux';
@@ -27,7 +28,6 @@ import {
 	getPubkyKeyBySignupTokenFromStore,
 	getSignedUpPubkysFromStore,
 } from '../store-helpers';
-import { showPubkySelectionSheet } from '../../hooks/inputHandlerUtils';
 
 type SignupActionData = {
 	action: InputAction.Signup;
@@ -37,13 +37,18 @@ type SignupActionData = {
 /**
  * Transitions the loading modal to error state via Redux
  */
-const showErrorState = (errorMessage: string, dispatch: Dispatch): void => {
+const showErrorState = (
+	errorMessage: string,
+	dispatch: Dispatch,
+	fields: LoadingErrorModalFields = {},
+): void => {
 	// Store dispatch for use in "Try again" button
 	setStoredDispatch(dispatch);
 	// Update Redux state to show error
 	dispatch(
 		setLoadingModalError({
 			isError: true,
+			...fields,
 			errorMessage: errorMessage,
 		}),
 	);
@@ -184,7 +189,7 @@ export const handleSignupAction = async (
 
 			// No existing pubkys - show error as before
 			const errorMessage = getErrorMessage(signupRes.error, i18n.t('errors.signupFailedDescription'));
-			showErrorState(errorMessage, dispatch);
+			showErrorState(errorMessage, dispatch, getSignupTokenErrorModalFields(errorMessage));
 			await openXError(xCallback, 'SIGNUP_FAILED', errorMessage);
 			return err(errorMessage);
 		}

--- a/src/utils/pubky.ts
+++ b/src/utils/pubky.ts
@@ -162,7 +162,7 @@ export const createPubkyWithInviteCode = async (
 
 				if (signinRes.isErr()) {
 					console.error('Signin also failed:', signinRes.error);
-					return err(i18n.t('pubkyErrors.invalidInviteCode'));
+					return err(signupRes.error);
 				}
 				console.log('Signin succeeded');
 			} else {

--- a/src/utils/signupErrors.ts
+++ b/src/utils/signupErrors.ts
@@ -1,0 +1,29 @@
+import i18n from '../i18n';
+
+export type LoadingErrorModalFields = {
+	errorDescription?: string;
+	errorModalTitle?: string;
+};
+
+export const getSignupTokenErrorDescription = (errorMessage: string): string | undefined => {
+	if (errorMessage.includes('Token already used')) {
+		return i18n.t('signup.alreadyUsedDescription');
+	} else if (errorMessage.includes('Token required')) {
+		return i18n.t('signup.requiredDescription');
+	} else if (errorMessage.includes('Invalid token')) {
+		return i18n.t('signup.invalidDescription');
+	}
+
+	return undefined;
+};
+
+export const getSignupTokenErrorModalFields = (errorMessage: string): LoadingErrorModalFields => {
+	const errorDescription = getSignupTokenErrorDescription(errorMessage);
+
+	if (!errorDescription) return {};
+
+	return {
+		errorDescription,
+		errorModalTitle: i18n.t('signup.invalidTitle'),
+	};
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,10 +2202,10 @@
     deepmerge "^4.3.1"
     svgo "^3.0.2"
 
-"@synonymdev/react-native-pubky@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-pubky/-/react-native-pubky-0.11.3.tgz#e31e929ed03f4afdfa95bdb7c286d295b19dba8e"
-  integrity sha512-EdUggk00H7+oonqBsNy0zZOU1eBR7d5zAfgYy4GMfyd+LXAe/ksapJ0KHXPvUcF7wNd76LHIoG7ETlTkdvwpLA==
+"@synonymdev/react-native-pubky@0.11.4":
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-pubky/-/react-native-pubky-0.11.4.tgz#cac11d830e7d1b474aa3650166a5d8c9d3abc2ce"
+  integrity sha512-WscC5xx/y8D0ZbALnXoFF3Up1r3ZlIR8LHrd8AtBSJ9DvPVMJ+bNeSPo8EmeW/rKL8AEumbOPHCdK1j1kHRB+g==
   dependencies:
     "@synonymdev/result" "^0.0.2"
 


### PR DESCRIPTION
## Summary

Shows specific invite/signup-token errors instead of generic failure messages when homeserver signup fails.

Closes https://github.com/pubky/pubky-ring/issues/252 https://github.com/pubky/pubky-ring/issues/183 https://github.com/pubky/pubky-ring/issues/86

This updates the invite and signup flows to preserve the original signup error, classify known token failures, and surface localized messages for:

- invalid invite token
- missing required invite token
- already-used invite token

The improved messaging is used in:

- LoadingModal invite flow
- LoadingModal signup flow
- Edit Pubky sheet
- Invite Code setup sheet

Also bumps `@synonymdev/react-native-pubky` to `0.11.4`, which preserves native signup error messages from the published package.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e556ed9d-66e8-45c3-96a9-bad64aa9c5e7" />
