### PR TITLE
test(e2e): stabilize e2e runs with reduced motion

### DIFF
--- a/.github/scripts/android-e2e.sh
+++ b/.github/scripts/android-e2e.sh
@@ -8,6 +8,8 @@ cd "$GITHUB_WORKSPACE/android"
 adb install -r app/build/outputs/apk/release/app-release.apk
 
 cd "$GITHUB_WORKSPACE"
+bash .maestro/scripts/prepare-device-motion.sh android
+
 INVITE_CODE="$(
   curl --fail --silent --show-error \
     -H "X-Admin-Password: $HOMESERVER_ADMIN_PASSWORD" \

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -102,6 +102,9 @@ jobs:
         xcrun simctl boot "$SIM_UDID" || true
         xcrun simctl bootstatus "$SIM_UDID" -b
 
+    - name: Enable reduced motion
+      run: bash .maestro/scripts/prepare-device-motion.sh ios
+
     - name: Build iOS simulator app
       run: |
         cd ios

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -34,6 +34,8 @@ The custom homeserver flow also requires:
 HOMESERVER_ADMIN_PASSWORD=... yarn e2e:android
 ```
 
+The local `yarn e2e:*` scripts prepare the target simulator/emulator for reduced motion before Maestro runs. The app respects that platform accessibility setting, so sheet and navigation animations are disabled without requiring a special e2e build.
+
 ## Continuous Integration
 
 `.github/workflows/ios-e2e.yml` builds the iOS simulator app, installs Maestro, boots an iPhone 17 simulator, installs the app, and runs all flows in `.maestro`.

--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -12,6 +12,13 @@ This is the Maestro E2E suite for iOS simulators and Android emulators.
 yarn e2e:ios
 ```
 
+To run a single flow locally, pass the flow name or path:
+
+```sh
+yarn e2e:ios onboarding
+yarn e2e:ios .maestro/flows/onboarding.yaml
+```
+
 The custom homeserver flow also requires:
 
 ```sh
@@ -26,6 +33,13 @@ HOMESERVER_ADMIN_PASSWORD=... yarn e2e:ios
 
 ```sh
 yarn e2e:android
+```
+
+To run a single flow locally, pass the flow name or path:
+
+```sh
+yarn e2e:android onboarding
+yarn e2e:android .maestro/flows/onboarding.yaml
 ```
 
 The custom homeserver flow also requires:

--- a/.maestro/flows/import-pubky-mnemonic.yaml
+++ b/.maestro/flows/import-pubky-mnemonic.yaml
@@ -11,13 +11,11 @@ name: import-pubky-mnemonic
     id: add-pubky-title
 - tapOn:
     id: AddPubkyImport
-    # retryTapIfNoChange: true
 - waitForAnimationToEnd
 - assertVisible:
     id: RecoveryPhraseButton
 - tapOn:
     id: RecoveryPhraseButton
-    # retryTapIfNoChange: true
 - waitForAnimationToEnd
 - assertVisible:
     id: MnemonicWordInput-1

--- a/.maestro/flows/onboarding.yaml
+++ b/.maestro/flows/onboarding.yaml
@@ -3,4 +3,21 @@ name: onboarding
 ---
 - launchApp:
     clearState: true
-- runFlow: ../shared/onboarding.yaml
+- assertVisible:
+    id: TermsTitle
+- swipe:
+    start: 50%, 60%
+    end: 50%, 18%
+    duration: 700
+- swipe:
+    start: 50%, 60%
+    end: 50%, 18%
+    duration: 700
+- assertNotVisible:
+    id: TermsTitle
+- tapOn:
+    id: TermsContinueButton
+- tapOn:
+    id: OnboardingContinueButton
+- assertVisible:
+    id: AddPubkyButton

--- a/.maestro/scripts/prepare-device-motion.sh
+++ b/.maestro/scripts/prepare-device-motion.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:-}"
+
+case "$platform" in
+  ios)
+    device="${SIM_UDID:-${IOS_SIM_UDID:-booted}}"
+
+    # Reduce Motion is read by React Native's AccessibilityInfo API on app start.
+    xcrun simctl spawn "$device" defaults write com.apple.Accessibility ReduceMotionEnabled -bool YES || true
+    xcrun simctl spawn "$device" defaults write com.apple.Accessibility ReduceMotion -bool YES || true
+    ;;
+  android)
+    adb shell settings put global window_animation_scale 0.0
+    adb shell settings put global transition_animation_scale 0.0
+    adb shell settings put global animator_duration_scale 0.0
+    ;;
+  *)
+    echo "Usage: $0 ios|android" >&2
+    exit 1
+    ;;
+esac

--- a/.maestro/scripts/restore-device-motion.sh
+++ b/.maestro/scripts/restore-device-motion.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:-}"
+
+case "$platform" in
+  ios)
+    device="${SIM_UDID:-${IOS_SIM_UDID:-booted}}"
+
+    xcrun simctl spawn "$device" defaults write com.apple.Accessibility ReduceMotionEnabled -bool NO || true
+    xcrun simctl spawn "$device" defaults write com.apple.Accessibility ReduceMotion -bool NO || true
+    ;;
+  android)
+    adb shell settings put global window_animation_scale 1.0
+    adb shell settings put global transition_animation_scale 1.0
+    adb shell settings put global animator_duration_scale 1.0
+    ;;
+  *)
+    echo "Usage: $0 ios|android" >&2
+    exit 1
+    ;;
+esac

--- a/.maestro/scripts/run-local.sh
+++ b/.maestro/scripts/run-local.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1:-}"
+
+case "$platform" in
+  android)
+    app_id="to.pubky.ring"
+    ;;
+  ios)
+    app_id="app.pubkyring"
+    ;;
+  *)
+    echo "Usage: $0 ios|android" >&2
+    exit 1
+    ;;
+esac
+
+bash .maestro/scripts/prepare-device-motion.sh "$platform"
+
+MAESTRO_CLI_NO_ANALYTICS=true \
+MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true \
+maestro --platform="$platform" test \
+  -e APP_ID="$app_id" \
+  -e HOMESERVER_ADMIN_PASSWORD="${HOMESERVER_ADMIN_PASSWORD:-}" \
+  .maestro

--- a/.maestro/scripts/run-local.sh
+++ b/.maestro/scripts/run-local.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 platform="${1:-}"
+flow="${2:-.maestro}"
 
 case "$platform" in
   android)
@@ -16,6 +17,20 @@ case "$platform" in
     ;;
 esac
 
+if [ "$flow" != ".maestro" ]; then
+  if [ -f "$flow" ]; then
+    flow_target="$flow"
+  elif [ -f ".maestro/flows/$flow" ]; then
+    flow_target=".maestro/flows/$flow"
+  elif [ -f ".maestro/flows/$flow.yaml" ]; then
+    flow_target=".maestro/flows/$flow.yaml"
+  else
+    flow_target="$flow"
+  fi
+else
+  flow_target=".maestro"
+fi
+
 bash .maestro/scripts/prepare-device-motion.sh "$platform"
 
 MAESTRO_CLI_NO_ANALYTICS=true \
@@ -23,4 +38,4 @@ MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true \
 maestro --platform="$platform" test \
   -e APP_ID="$app_id" \
   -e HOMESERVER_ADMIN_PASSWORD="${HOMESERVER_ADMIN_PASSWORD:-}" \
-  .maestro
+  "$flow_target"

--- a/.maestro/shared/onboarding.yaml
+++ b/.maestro/shared/onboarding.yaml
@@ -2,16 +2,6 @@ appId: ${APP_ID}
 ---
 - assertVisible:
     id: TermsTitle
-- swipe:
-    start: 50%, 60%
-    end: 50%, 18%
-    duration: 700
-- swipe:
-    start: 50%, 60%
-    end: 50%, 18%
-    duration: 700
-- assertNotVisible:
-    id: TermsTitle
 - tapOn:
     id: TermsContinueButton
 - tapOn:

--- a/.maestro/shared/signup.yaml
+++ b/.maestro/shared/signup.yaml
@@ -8,6 +8,7 @@ env:
     id: PubkyBox--0-ActionButton
 - tapOn:
     id: PubkyBox--0-ActionButton
+- waitForAnimationToEnd
 - assertVisible:
     id: EditPubkyNameInput
 - tapOn:

--- a/README.md
+++ b/README.md
@@ -124,36 +124,4 @@ sha256sum -c SHA256SUMS
 
 ## E2E testing (Maestro)
 
-This project runs iOS simulator and Android emulator E2E tests with Maestro.
-
-### Prerequisites
-- Xcode with an iOS Simulator.
-- Android SDK with an emulator.
-- Maestro installed locally: `curl -Ls "https://get.maestro.mobile.dev" | bash`.
-- The app built and installed on the target simulator or emulator.
-
-### Run tests
-
-```bash
-yarn e2e:ios
-yarn e2e:android
-```
-
-### Environment overrides
-- `HOMESERVER_ADMIN_PASSWORD`: required for the custom homeserver flow.
-
-### Examples
-
-```bash
-# Run all iOS flows against the installed app
-yarn e2e:ios
-
-# Run all Android flows against the installed app
-yarn e2e:android
-
-# Run flows that request a staging invite code
-HOMESERVER_ADMIN_PASSWORD=... yarn e2e:ios
-HOMESERVER_ADMIN_PASSWORD=... yarn e2e:android
-```
-
-The e2e scripts prepare the target simulator or emulator for reduced motion before Maestro runs. The app respects that platform accessibility setting, so sheet and navigation animations are disabled without requiring a special e2e build.
+E2E tests use Maestro. See [`.maestro/README.md`](.maestro/README.md) for local and CI usage.

--- a/README.md
+++ b/README.md
@@ -155,3 +155,5 @@ yarn e2e:android
 HOMESERVER_ADMIN_PASSWORD=... yarn e2e:ios
 HOMESERVER_ADMIN_PASSWORD=... yarn e2e:android
 ```
+
+The e2e scripts prepare the target simulator or emulator for reduced motion before Maestro runs. The app respects that platform accessibility setting, so sheet and navigation animations are disabled without requiring a special e2e build.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "icons:build": "node scripts/build-icons.mjs",
     "optimize-images": "node scripts/optimize-images.js",
     "test": "jest",
-    "e2e:android": "MAESTRO_CLI_NO_ANALYTICS=true MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true maestro --platform=android test -e APP_ID=to.pubky.ring -e HOMESERVER_ADMIN_PASSWORD=\"$HOMESERVER_ADMIN_PASSWORD\" .maestro",
-    "e2e:ios": "MAESTRO_CLI_NO_ANALYTICS=true MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true maestro --platform=ios test -e APP_ID=app.pubkyring -e HOMESERVER_ADMIN_PASSWORD=\"$HOMESERVER_ADMIN_PASSWORD\" .maestro",
+    "e2e:android": "bash .maestro/scripts/run-local.sh android",
+    "e2e:ios": "bash .maestro/scripts/run-local.sh ios",
+    "e2e:restore-motion:android": "bash .maestro/scripts/restore-device-motion.sh android",
+    "e2e:restore-motion:ios": "bash .maestro/scripts/restore-device-motion.sh ios",
     "tx:push": "./tx push -s",
     "tx:pull": "./tx pull -a",
     "postinstall": "patch-package"

--- a/src/components/CircularProgressBar.tsx
+++ b/src/components/CircularProgressBar.tsx
@@ -8,7 +8,6 @@ type CircularProgressBarProps = {
 	unfilledColor?: string;
 	filledColor?: string;
 	drain?: boolean;
-	onComplete?: () => void;
 };
 
 const CircularProgressBar = ({
@@ -18,26 +17,18 @@ const CircularProgressBar = ({
 	unfilledColor = '#333333',
 	filledColor = '#FFFFFF',
 	drain = false,
-	onComplete,
 }: CircularProgressBarProps): React.ReactElement => {
 	const [progress, setProgress] = useState(drain ? 1 : 0);
 	const animationFrame = useRef<number | null>(null);
-	const completedOnce = useRef(false);
-	const onCompleteRef = useRef(onComplete);
 	const radius = (size - strokeWidth) / 2;
 	const center = size / 2;
 	const circumference = 2 * Math.PI * radius;
 	const strokeDashoffset = circumference * (1 - progress);
 
 	useEffect(() => {
-		onCompleteRef.current = onComplete;
-	}, [onComplete]);
-
-	useEffect(() => {
 		const startTime = Date.now();
 		const safeDuration = Math.max(duration, 1);
 
-		completedOnce.current = false;
 		setProgress(drain ? 1 : 0);
 
 		const updateProgress = (): void => {
@@ -47,10 +38,6 @@ const CircularProgressBar = ({
 			setProgress(drain ? 1 - nextProgress : nextProgress);
 
 			if (nextProgress >= 1) {
-				if (onCompleteRef.current && !completedOnce.current) {
-					completedOnce.current = true;
-					onCompleteRef.current();
-				}
 				return;
 			}
 

--- a/src/components/ConfirmAuth.tsx
+++ b/src/components/ConfirmAuth.tsx
@@ -120,6 +120,18 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 		handleClose();
 	}, [xCallback, handleClose]);
 
+	useEffect(() => {
+		if (isAuthorized) {
+			return;
+		}
+
+		const timeout = setTimeout(handleDeny, CONFIRM_AUTH_TIMEOUT_MS);
+
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, [handleDeny, isAuthorized]);
+
 	const handleAuth = useCallback(async () => {
 		setAuthorizing(true);
 		try {
@@ -180,12 +192,7 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 
 	const headerProgress =
 		Platform.OS === 'android' && !isAuthorized ? (
-			<CircularProgressBar
-				duration={CONFIRM_AUTH_TIMEOUT_MS}
-				size={20}
-				drain={true}
-				onComplete={handleDeny}
-			/>
+			<CircularProgressBar duration={CONFIRM_AUTH_TIMEOUT_MS} size={20} drain={true} />
 		) : undefined;
 
 	return (
@@ -258,7 +265,6 @@ const ConfirmAuth = ({ payload }: { payload: ConfirmAuthProps }): ReactElement =
 						unfilledColor="#333333"
 						height={5}
 						drain={true}
-						onComplete={handleDeny}
 					/>
 				)}
 			</View>

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useRef, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import Animated, {
 	Easing,
@@ -7,7 +7,6 @@ import Animated, {
 	useSharedValue,
 	withTiming,
 } from 'react-native-reanimated';
-import { scheduleOnRN } from 'react-native-worklets';
 
 type ProgressBarProps = {
 	duration?: number; // ms
@@ -21,7 +20,6 @@ type ProgressBarProps = {
 	borderRadius?: number;
 	reverse?: boolean; // if true, anchors progress to the right edge
 	drain?: boolean; // if true, progress starts full and drains to empty
-	onComplete?: () => void;
 	style?: ViewStyle | ViewStyle[];
 };
 
@@ -37,14 +35,12 @@ const ProgressBar = ({
 	borderRadius = 2,
 	reverse = false,
 	drain = false,
-	onComplete,
 	style,
 }: ProgressBarProps): React.ReactElement | null => {
 	const [shouldRender, setShouldRender] = useState(delayRender === 0);
 	const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
 	const progress = useSharedValue(drain ? 1 : 0);
 	const opacity = useSharedValue(fadeIn ? 0 : 1);
-	const completedOnce = useRef(false);
 
 	const containerStyle = useAnimatedStyle(() => ({
 		opacity: opacity.value,
@@ -76,7 +72,6 @@ const ProgressBar = ({
 		if (!shouldRender || dimensions.width === 0) return;
 
 		// restart animation whenever duration or delay changes
-		completedOnce.current = false;
 		cancelAnimation(progress);
 		cancelAnimation(opacity);
 		progress.value = drain ? 1 : 0;
@@ -92,12 +87,7 @@ const ProgressBar = ({
 
 		// Start progress animation after delay
 		const timer = setTimeout(() => {
-			progress.value = withTiming(drain ? 0 : 1, { duration, easing: Easing.linear }, finished => {
-				if (finished && onComplete && !completedOnce.current) {
-					completedOnce.current = true;
-					scheduleOnRN(onComplete);
-				}
-			});
+			progress.value = withTiming(drain ? 0 : 1, { duration, easing: Easing.linear });
 		}, delayStart);
 
 		return (): void => {
@@ -106,7 +96,7 @@ const ProgressBar = ({
 			cancelAnimation(opacity);
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [shouldRender, dimensions.width, duration, delayStart, fadeIn, fadeInDuration, drain, onComplete]);
+	}, [shouldRender, dimensions.width, duration, delayStart, fadeIn, fadeInDuration, drain]);
 
 	if (!shouldRender) {
 		return (

--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -15,6 +15,7 @@ import { BodyMBText } from '../theme/typography.ts';
 import HeaderNavButton from './HeaderNavButton.tsx';
 import { HEADER_HEIGHT } from './AppHeader.tsx';
 import { ArrowLeft } from '../icons/index.ts';
+import { useReducedMotion } from '../hooks/useReducedMotion.ts';
 
 type GradientType = 'none' | 'brand' | 'danger';
 
@@ -56,6 +57,7 @@ const Sheet = ({
 	const { height: windowHeight } = useWindowDimensions();
 	const insets = useSafeAreaInsets();
 	const navigationAnimation = useSelector(getNavigationAnimation);
+	const reducedMotionEnabled = useReducedMotion();
 	const fullHeight = windowHeight - insets.top;
 	const sheetHeight = smallScreen ? fullHeight : fullHeight - HEADER_HEIGHT - 12;
 
@@ -65,7 +67,7 @@ const Sheet = ({
 			containerStyle={[styles.sheetContainer, { height: sheetHeight }]}
 			defaultOverlayOpacity={0.7}
 			gestureEnabled={true}
-			animated={true}
+			animated={!reducedMotionEnabled}
 			drawUnderStatusBar={false}
 			useBottomSafeAreaPadding={false}
 			keyboardHandlerEnabled={keyboardHandlerEnabled}

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export const useReducedMotion = (): boolean => {
+	const [reducedMotionEnabled, setReducedMotionEnabled] = useState(false);
+
+	useEffect(() => {
+		let mounted = true;
+
+		AccessibilityInfo.isReduceMotionEnabled().then(enabled => {
+			if (mounted) {
+				setReducedMotionEnabled(enabled);
+			}
+		});
+
+		const subscription = AccessibilityInfo.addEventListener('reduceMotionChanged', setReducedMotionEnabled);
+
+		return () => {
+			mounted = false;
+			subscription.remove();
+		};
+	}, []);
+
+	return reducedMotionEnabled;
+};

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -17,6 +17,7 @@ import TermsOfUse from '../screens/TermsOfUse.tsx';
 import About from '../screens/About.tsx';
 import { useTranslation } from 'react-i18next';
 import { NAVIGATION_ANIMATION_DURATION } from '../utils/constants';
+import { useReducedMotion } from '../hooks/useReducedMotion.ts';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -25,7 +26,9 @@ const RootNavigator = (): ReactElement => {
 	const showOnboarding = useSelector(getShowOnboarding);
 	const signedTermsOfUse = useSelector(getSignedTermsOfUse);
 	const navigationAnimation = useSelector(getNavigationAnimation);
+	const reducedMotionEnabled = useReducedMotion();
 	const theme = useTheme();
+
 	const initialRoute = useMemo(() => {
 		return !signedTermsOfUse ? 'TermsOfUse' : showOnboarding ? 'Onboarding' : 'Home';
 	}, [showOnboarding, signedTermsOfUse]);
@@ -49,8 +52,8 @@ const RootNavigator = (): ReactElement => {
 				initialRouteName={initialRoute}
 				screenOptions={{
 					headerShown: false,
-					animation: navigationAnimation,
-					animationDuration: NAVIGATION_ANIMATION_DURATION,
+					animation: reducedMotionEnabled ? 'none' : navigationAnimation,
+					animationDuration: reducedMotionEnabled ? 0 : NAVIGATION_ANIMATION_DURATION,
 				}}
 			>
 				<Stack.Screen


### PR DESCRIPTION
## Summary

- Enables reduced motion before local and CI Maestro e2e runs.
- Makes the app respect the platform Reduce Motion setting by disabling sheet and navigation animations.
- Adds local helper scripts for running e2e and restoring normal device animations.
- Stabilizes signup by waiting for the setup sheet to settle before targeting inputs.
- Moves auth timeout handling out of progress bar animation callbacks and into a JS timer.
- Removes unused `onComplete` callback plumbing from progress bar components.
