### PR TITLE
chore: remove stale AsyncStorage native references

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,9 +23,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url("$rootDir/../node_modules/@react-native-async-storage/async-storage/android/local_repo")
-        }
     }
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,26 +1,4 @@
 PODS:
-  - AsyncStorage (3.0.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
   - BVLinearGradient (2.8.3):
     - React-Core
   - FBLazyVector (0.85.2)
@@ -2467,7 +2445,6 @@ PODS:
   - ZXingObjC/All (3.6.9)
 
 DEPENDENCIES:
-  - "AsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -2573,8 +2550,6 @@ SPEC REPOS:
     - ZXingObjC
 
 EXTERNAL SOURCES:
-  AsyncStorage:
-    :path: "../node_modules/@react-native-async-storage/async-storage"
   BVLinearGradient:
     :path: "../node_modules/react-native-linear-gradient"
   FBLazyVector:
@@ -2772,7 +2747,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AsyncStorage: 857a13f3c66a30d6b02efa09babba3d457e8e8ca
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
   hermes-engine: b7e15148e472e2e950c9851defad3d5b84d0c8eb

--- a/ios/pubkyring/PrivacyInfo.xcprivacy
+++ b/ios/pubkyring/PrivacyInfo.xcprivacy
@@ -6,20 +6,20 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
 				<string>0A2A.1</string>
 				<string>3B52.1</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>CA92.1</string>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
## Summary

Couple of missed changes from https://github.com/pubky/pubky-ring/pull/326 that caused builds to fail.

- Regenerate iOS pods to remove stale `AsyncStorage` from `Podfile.lock`
- Remove the obsolete AsyncStorage Android local Maven repository
- Fix iOS builds failing on missing `AsyncStorage-AsyncStorage_resources/PrivacyInfo.xcprivacy`

## Verification
- Confirmed `yarn ios` builds successfully
