### PR TITLE
fix: use staging Pubky config in dev

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,12 +3,15 @@
 export const BLUE_RADIAL_GRADIENT = ['#0b2033', 'rgba(0, 0, 0, 0.1)'];
 export const RED_RADIAL_GRADIENT = ['rgba(233, 81, 100, 0.32)', 'rgba(0, 0, 0, 0.1)'];
 
+export const IS_STAGING = __DEV__;
 export const STAGING_HOMESERVER = 'ufibwbmed6jeq9k4p583go95wofakh9fwpp4k734trq79pd9u1uy';
 export const PRODUCTION_HOMESERVER = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
-export const DEFAULT_HOMESERVER = PRODUCTION_HOMESERVER;
 export const STAGING_APP_URL = 'https://staging.pubky.app';
 export const PRODUCTION_APP_URL = 'https://pubky.app';
-export const PUBKY_APP_URL = PRODUCTION_APP_URL;
+export const STAGING_APP_HOST = STAGING_APP_URL.replace('https://', '');
+export const PRODUCTION_APP_HOST = PRODUCTION_APP_URL.replace('https://', '');
+export const DEFAULT_HOMESERVER = IS_STAGING ? STAGING_HOMESERVER : PRODUCTION_HOMESERVER;
+export const PUBKY_APP_URL = IS_STAGING ? STAGING_APP_URL : PRODUCTION_APP_URL;
 export const TERMS_OF_USE = 'https://synonym.to/pubky-ring-privacy-policy';
 
 // Timing constants for consistent animations and delays
@@ -16,8 +19,6 @@ export const NAVIGATION_ANIMATION_DURATION = 200; // Duration for screen transit
 export const SHEET_ANIMATION_DELAY = 50; // Delay for sheet animations
 export const SHEET_TRANSITION_DELAY = 50; // Delay between sheet transitions
 export const AUTH_SHEET_DELAY = 50; // Small delay for auth sheet display
-export const ANDROID_DEEPLINK_DELAY = 50; // Delay before opening Android deep links
 export const SCANNER_CLOSE_DELAY = 50; // Delay after closing scanner before opening new sheet
 
-export const ENABLE_INVITE_SCANNER = true; // Toggle for enabling invite code scanner feature
 export const BACKUP_PASSWORD_CHAR_MIN = 6; // Minimum characters for file backup password

--- a/src/utils/pubky.ts
+++ b/src/utils/pubky.ts
@@ -31,7 +31,13 @@ import { getErrorMessage } from './errorHandler.ts';
 import { auth } from '@synonymdev/react-native-pubky';
 import { getPubkyDataFromStore } from './store-helpers.ts';
 import { EBackupPreference, IKeychainData, TProfile } from '../types/pubky.ts';
-import { DEFAULT_HOMESERVER, STAGING_HOMESERVER } from './constants.ts';
+import {
+	DEFAULT_HOMESERVER,
+	PRODUCTION_APP_HOST,
+	PRODUCTION_HOMESERVER,
+	STAGING_APP_HOST,
+	STAGING_HOMESERVER,
+} from './constants.ts';
 import i18n from '../i18n';
 
 export const getSignupToken = ({
@@ -309,8 +315,8 @@ export const importPubky = async ({
 				dispatch(setHomeserver({ pubky, homeserver }));
 			}
 			// If they're using Synonym's default or staging homeserver, fetch the profile name and set it accordingly.
-			if (homeserver === DEFAULT_HOMESERVER || homeserver === STAGING_HOMESERVER) {
-				const app = homeserver === DEFAULT_HOMESERVER ? 'pubky.app' : 'staging.pubky.app';
+			if (homeserver === PRODUCTION_HOMESERVER || homeserver === STAGING_HOMESERVER) {
+				const app = homeserver === STAGING_HOMESERVER ? STAGING_APP_HOST : PRODUCTION_APP_HOST;
 				const profileInfo = await getProfileInfo(pubky, app);
 				if (profileInfo.isOk() && profileInfo.value.name) {
 					dispatch(


### PR DESCRIPTION
## Summary

- Derive the default homeserver and Pubky app URL from `__DEV__`
- Use staging homeserver/app URL in development builds and production values in release builds
- Fix profile lookup host selection so staging and production homeservers map to the correct Pubky app host explicitly
