### PR TITLE
test(e2e): add backup file import coverage

### DIFF
--- a/.maestro/flows/backup-and-import-file.yaml
+++ b/.maestro/flows/backup-and-import-file.yaml
@@ -1,0 +1,103 @@
+appId: ${APP_ID}
+name: backup-and-import-file
+env:
+  BACKUP_PASSWORD: testpass123
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow: ../shared/create-pubky.yaml
+- runFlow: ../shared/close-sheet.yaml
+- tapOn:
+    id: PubkyBox-BackupButton
+- assertVisible:
+    id: select-backup-preference-title
+- tapOn:
+    id: SelectBackupPreferenceEncryptedFileButton
+- extendedWaitUntil:
+    visible:
+      id: backup-prompt-title
+    timeout: 10000
+- tapOn:
+    id: BackupFilePassphraseInput
+- inputText: ${BACKUP_PASSWORD}
+- tapOn:
+    id: BackupFileSubmitButton
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      - extendedWaitUntil:
+          visible: Pubky Ring
+          timeout: 10000
+      - tapOn:
+          point: 87%,13%
+- extendedWaitUntil:
+    visible:
+      id: AddPubkyButton
+    timeout: 30000
+- runFlow: ../shared/delete.yaml
+- tapOn:
+    id: AddPubkyButton
+- waitForAnimationToEnd
+- assertVisible:
+    id: add-pubky-title
+- tapOn:
+    id: AddPubkyImport
+- waitForAnimationToEnd
+- tapOn:
+    id: EncryptedFileButton
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      # iOS Files may open in Recents locally and in CI. Local Recents often has
+      # the exported backup, while clean CI simulators can show an empty Recents
+      # tab. In that case Browse returns to the app folder used when saving the
+      # backup. That folder also contains mmkv, so select the second grid item.
+      - runFlow:
+          when:
+            visible: No Recents
+          commands:
+            - tapOn: Browse
+            - waitForAnimationToEnd
+            - tapOn:
+                point: 50%,32%
+      - runFlow:
+          when:
+            notVisible: No Recents
+          commands:
+            - tapOn:
+                point: 17%,31%
+- runFlow:
+    when:
+      platform: android
+    commands:
+      # Android DocumentsUI remembers its last folder. CI usually starts in Recents,
+      # while local runs may reopen directly in Downloads/PubkyRing.
+      - runFlow:
+          when:
+            visible: Recent
+          commands:
+            - tapOn:
+                point: 7%,9%
+            - tapOn: Downloads
+            - tapOn: PubkyRing
+      - extendedWaitUntil:
+          visible: .*\.pkarr
+          timeout: 30000
+      - tapOn:
+          point: 28%,52%
+- extendedWaitUntil:
+    visible:
+      id: BackupFilePassphraseInput
+    timeout: 30000
+- tapOn:
+    id: BackupFilePassphraseInput
+- inputText: ${BACKUP_PASSWORD}
+- tapOn:
+    id: BackupFileSubmitButton
+- extendedWaitUntil:
+    visible:
+      id: import-success-title
+    timeout: 30000

--- a/.maestro/scripts/run-local.sh
+++ b/.maestro/scripts/run-local.sh
@@ -31,6 +31,34 @@ else
   flow_target=".maestro"
 fi
 
+cleanup_ios_backup_files() {
+  local simulator_root="$HOME/Library/Developer/CoreSimulator/Devices"
+  local udids
+
+  udids="$(xcrun simctl list devices booted | awk -F'[()]' '/Booted/{print $2}')"
+
+  while IFS= read -r udid; do
+    [ -n "$udid" ] || continue
+
+    find "$simulator_root/$udid/data/Containers/Shared/AppGroup" \
+      -path "*/File Provider Storage/pubky-backup-*.pkarr" \
+      -type f \
+      -delete 2>/dev/null || true
+  done <<< "$udids"
+}
+
+cleanup_android_backup_files() {
+  adb shell 'rm -f /sdcard/Download/PubkyRing/pubky-backup-*.pkarr' || true
+}
+
+if [ "$platform" = "ios" ] && [ "$(basename "$flow_target")" = "backup-and-import-file.yaml" ]; then
+  cleanup_ios_backup_files
+fi
+
+if [ "$platform" = "android" ] && [ "$(basename "$flow_target")" = "backup-and-import-file.yaml" ]; then
+  cleanup_android_backup_files
+fi
+
 bash .maestro/scripts/prepare-device-motion.sh "$platform"
 
 MAESTRO_CLI_NO_ANALYTICS=true \

--- a/.maestro/shared/delete.yaml
+++ b/.maestro/shared/delete.yaml
@@ -1,0 +1,14 @@
+appId: ${APP_ID}
+---
+- tapOn:
+    id: PubkyBox--0
+- assertVisible:
+    id: PubkyDetailDeleteButton
+- tapOn:
+    id: PubkyDetailDeleteButton
+- assertVisible:
+    id: delete-pubky-title
+- tapOn:
+    id: DeletePubkyConfirmButton
+- assertVisible:
+    id: AddPubkyButton

--- a/src/components/BackupPrompt.tsx
+++ b/src/components/BackupPrompt.tsx
@@ -177,6 +177,7 @@ const BackupPrompt = ({
 					textContentType="none"
 					importantForAutofill="no"
 					spellCheck={false}
+					testID="BackupFilePassphraseInput"
 				/>
 				<TouchableOpacity
 					style={styles.eyeButton}
@@ -192,12 +193,18 @@ const BackupPrompt = ({
 				</BodySText>
 			) : null}
 			<View style={styles.buttonContainer}>
-				<Button text={loading ? t('common.close') : t('common.cancel')} size="large" onPress={handleClose} />
+				<Button
+					text={loading ? t('common.close') : t('common.cancel')}
+					size="large"
+					testID="BackupFileCancelButton"
+					onPress={handleClose}
+				/>
 				<Button
 					text={submitButtonText}
 					size="large"
 					variant="secondary"
 					loading={loading}
+					testID="BackupFileSubmitButton"
 					onPress={handleSubmit}
 					disabled={
 						!password.trim() ||

--- a/src/components/PubkyBox.tsx
+++ b/src/components/PubkyBox.tsx
@@ -36,7 +36,11 @@ const PubkyInfo = memo(({ pubkyName, publicKey, sessionsCount, isBackedUp }: Pub
 					{truncateStr(publicKey)}
 				</BodySSBText>
 				{!isBackedUp && (
-					<TouchableOpacity onPress={handleBackupPress} style={styles.backupContainer}>
+					<TouchableOpacity
+						style={styles.backupContainer}
+						testID="PubkyBox-BackupButton"
+						onPress={handleBackupPress}
+					>
 						<BodySSBUnspacedText colorName="pubkyRing">
 							{t('pubkyProfile.backupReminder')}
 						</BodySSBUnspacedText>

--- a/src/components/SelectBackupPreference.tsx
+++ b/src/components/SelectBackupPreference.tsx
@@ -46,11 +46,17 @@ const SelectBackupPreference = ({ payload: { pubky } }: { payload: { pubky: stri
 				<Image source={require('../images/shield.png')} style={styles.image} />
 			</View>
 			<View style={styles.buttonContainer}>
-				<Button text={t('backup.encryptedFile')} size="large" onPress={onEncryptedFilePress} />
+				<Button
+					text={t('backup.encryptedFile')}
+					size="large"
+					testID="SelectBackupPreferenceEncryptedFileButton"
+					onPress={onEncryptedFilePress}
+				/>
 				<Button
 					text={t('backup.recoveryPhrase')}
 					size="large"
 					variant="secondary"
+					testID="SelectBackupPreferenceRecoveryPhraseButton"
 					onPress={onRecoveryPhrasePress}
 				/>
 			</View>

--- a/src/utils/rnfs.ts
+++ b/src/utils/rnfs.ts
@@ -9,6 +9,7 @@ import { pick, keepLocalCopy } from '@react-native-documents/picker';
 import Share, { ShareOptions } from 'react-native-share';
 import { SheetManager } from 'react-native-actions-sheet';
 import { EBackupPromptViewId } from './sheetHelpers.ts';
+import { NAVIGATION_ANIMATION_DURATION } from './constants.ts';
 
 const Buffer = require('buffer').Buffer;
 
@@ -162,6 +163,13 @@ export const showImportPrompt = ({
 	dispatch: Dispatch;
 }): Promise<Result<string>> => {
 	return new Promise(resolve => {
+		let completedResult: Result<string> | undefined;
+		const resolveAfterClose = (result: Result<string>): void => {
+			completedResult = result;
+			SheetManager.hide('backup-prompt').then(() => resolve(result));
+			setTimeout(() => resolve(result), NAVIGATION_ANIMATION_DURATION);
+		};
+
 		SheetManager.show('backup-prompt', {
 			payload: {
 				fileName,
@@ -187,9 +195,9 @@ export const showImportPrompt = ({
 						}
 
 						console.log('Successfully imported pubky from encrypted file');
-						SheetManager.hide('backup-prompt').then();
-						resolve(ok(pubky.value));
-						return ok(pubky.value);
+						const result = ok(pubky.value);
+						resolveAfterClose(result);
+						return result;
 					} catch (error) {
 						const errorMsg = `Unexpected error during import: ${JSON.stringify(error)}`;
 						resolve(err(errorMsg));
@@ -197,7 +205,7 @@ export const showImportPrompt = ({
 					}
 				},
 				onClose: () => {
-					resolve(err(''));
+					resolve(completedResult ?? err(''));
 				},
 			},
 		});
@@ -226,6 +234,7 @@ export async function backupPubky(content: string, filename: string): Promise<Re
 				subject: 'Pubky Backup',
 				title: 'Save Pubky Backup',
 				failOnCancel: false,
+				saveToFiles: true,
 			};
 
 			// Show the native share sheet


### PR DESCRIPTION
## Summary

- Add a Maestro flow covering encrypted file backup, pubky deletion, and encrypted file import
- Add stable test IDs for the home backup button, backup passphrase controls, and backup preference buttons
- Add a shared Maestro delete helper for deleting the first pubky
- Clean stale exported `.pkarr` files before running the backup/import flow locally
- Use the iOS Files save flow directly via `saveToFiles`
- Resolve encrypted-file import after the backup prompt closes so the import success sheet can open reliably

https://github.com/user-attachments/assets/f37371f1-5ece-4a0c-b004-13331fbe98ff

## Testing

- `yarn typecheck`
- `yarn e2e:ios backup-and-import-file`
