### PR TITLE
feat(settings): add sunset notice test mode toggle

### DIFF
--- a/__tests__/useReplacementRelease.test.ts
+++ b/__tests__/useReplacementRelease.test.ts
@@ -23,6 +23,23 @@ const validRelease = {
 	],
 };
 
+const legacyRelease = {
+	draft: false,
+	prerelease: false,
+	html_url: 'https://github.com/pubky/pubky-ring/releases/tag/v1.16',
+	assets: [
+		{
+			name: 'SHA256SUMS',
+			browser_download_url: 'https://github.com/pubky/pubky-ring/releases/download/v1.16/SHA256SUMS',
+		},
+		{
+			name: 'app-universal-release-1.16-23.apk',
+			browser_download_url:
+				'https://github.com/pubky/pubky-ring/releases/download/v1.16/app-universal-release-1.16-23.apk',
+		},
+	],
+};
+
 function memoryStorage(initial?: string): ReplacementReleaseStorage & { value?: string } {
 	return {
 		value: initial,
@@ -60,6 +77,32 @@ describe('parseReplacementRelease', () => {
 		expect(parseReplacementRelease(release)).toBeNull();
 	});
 
+	test('rejects a release that only ships the legacy APK', () => {
+		expect(parseReplacementRelease(legacyRelease)).toBeNull();
+	});
+
+	test('accepts any published APK in test mode', () => {
+		expect(parseReplacementRelease(legacyRelease, { allowAnyApk: true })).toEqual({
+			releaseUrl: legacyRelease.html_url,
+			apkUrl: legacyRelease.assets[1].browser_download_url,
+		});
+	});
+
+	test('prefers the replacement APK in test mode', () => {
+		const release = { ...validRelease, assets: [...legacyRelease.assets, ...validRelease.assets] };
+		expect(parseReplacementRelease(release, { allowAnyApk: true })?.apkUrl).toBe(
+			validRelease.assets[0].browser_download_url,
+		);
+	});
+
+	test('still rejects an untrusted APK host in test mode', () => {
+		const release = {
+			...legacyRelease,
+			assets: [{ ...legacyRelease.assets[1], browser_download_url: 'https://evil.example/file.apk' }],
+		};
+		expect(parseReplacementRelease(release, { allowAnyApk: true })).toBeNull();
+	});
+
 	test('accepts GitHub object storage for the APK', () => {
 		const release = {
 			...validRelease,
@@ -79,7 +122,7 @@ describe('detectReplacementRelease', () => {
 		const storage = memoryStorage();
 		const fetcher = jest.fn(async () => ({ ok: true, json: async () => validRelease }));
 
-		const result = await detectReplacementRelease(storage, fetcher);
+		const result = await detectReplacementRelease({ storage, fetcher });
 
 		expect(fetcher).toHaveBeenCalledWith(
 			REPLACEMENT_RELEASE_ENDPOINT,
@@ -96,9 +139,9 @@ describe('detectReplacementRelease', () => {
 		};
 		const fetcher = jest.fn();
 
-		await expect(detectReplacementRelease(memoryStorage(JSON.stringify(stored)), fetcher)).resolves.toEqual(
-			stored,
-		);
+		await expect(
+			detectReplacementRelease({ storage: memoryStorage(JSON.stringify(stored)), fetcher }),
+		).resolves.toEqual(stored);
 		expect(fetcher).not.toHaveBeenCalled();
 	});
 
@@ -110,7 +153,7 @@ describe('detectReplacementRelease', () => {
 		}),
 	])('fails closed without persisting', async fetcher => {
 		const storage = memoryStorage();
-		await expect(detectReplacementRelease(storage, fetcher)).resolves.toBeNull();
+		await expect(detectReplacementRelease({ storage, fetcher })).resolves.toBeNull();
 		expect(storage.value).toBeUndefined();
 	});
 
@@ -122,10 +165,37 @@ describe('detectReplacementRelease', () => {
 					init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
 				}),
 		);
-		const result = detectReplacementRelease(memoryStorage(), fetcher, 100);
+		const result = detectReplacementRelease({ storage: memoryStorage(), fetcher, timeoutMs: 100 });
 
 		jest.advanceTimersByTime(100);
 		await expect(result).resolves.toBeNull();
 		jest.useRealTimers();
+	});
+
+	test('test mode activates on the latest published APK without persisting', async () => {
+		const storage = memoryStorage();
+		const fetcher = jest.fn(async () => ({ ok: true, json: async () => legacyRelease }));
+
+		const result = await detectReplacementRelease({ storage, fetcher, testMode: true });
+
+		expect(result?.apkUrl).toBe(legacyRelease.assets[1].browser_download_url);
+		expect(storage.value).toBeUndefined();
+	});
+
+	test('test mode refetches instead of reusing a persisted activation', async () => {
+		const stored = {
+			releaseUrl: validRelease.html_url,
+			apkUrl: validRelease.assets[0].browser_download_url,
+		};
+		const fetcher = jest.fn(async () => ({ ok: true, json: async () => legacyRelease }));
+
+		const result = await detectReplacementRelease({
+			storage: memoryStorage(JSON.stringify(stored)),
+			fetcher,
+			testMode: true,
+		});
+
+		expect(fetcher).toHaveBeenCalledTimes(1);
+		expect(result?.apkUrl).toBe(legacyRelease.assets[1].browser_download_url);
 	});
 });

--- a/src/hooks/useReplacementRelease.ts
+++ b/src/hooks/useReplacementRelease.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
 import { createMMKV } from 'react-native-mmkv';
 import { appApplicationId } from '../utils/appInfo.ts';
@@ -8,6 +8,7 @@ export const REPLACEMENT_RELEASE_ENDPOINT = 'https://api.github.com/repos/pubky/
 export const LEGACY_ANDROID_APPLICATION_ID = 'to.pubky.ring';
 
 const ACTIVATION_STORAGE_KEY = 'legacySunset.replacementRelease';
+const TEST_MODE_STORAGE_KEY = 'legacySunset.testMode';
 const REQUEST_TIMEOUT_MS = 5_000;
 
 export type ReplacementRelease = {
@@ -42,7 +43,27 @@ type Fetcher = (
 	init?: { signal?: AbortSignal; headers?: Record<string, string> },
 ) => Promise<FetchResponse>;
 
-const storage = createMMKV();
+export type ParseReplacementReleaseOptions = {
+	/** Accept any APK asset instead of only the replacement package APK. Test mode only. */
+	allowAnyApk?: boolean;
+};
+
+export type DetectReplacementReleaseOptions = {
+	storage?: ReplacementReleaseStorage;
+	fetcher?: Fetcher;
+	timeoutMs?: number;
+	/** Match any published APK and never read or write the persisted activation. */
+	testMode?: boolean;
+};
+
+type DetectionResult = {
+	testMode: boolean;
+	release: ReplacementRelease | null;
+};
+
+const defaultStorage = createMMKV();
+const testModeListeners = new Set<() => void>();
+let testMode: boolean | undefined;
 let sessionCheck: Promise<ReplacementRelease | null> | undefined;
 
 function isAllowedReleaseUrl(value: unknown): value is string {
@@ -74,7 +95,22 @@ function isAllowedApkUrl(value: unknown): value is string {
 	}
 }
 
-export function parseReplacementRelease(payload: unknown): ReplacementRelease | null {
+function isApkAsset(asset: GithubAsset): boolean {
+	return (
+		typeof asset?.name === 'string' &&
+		asset.name.endsWith('.apk') &&
+		isAllowedApkUrl(asset.browser_download_url)
+	);
+}
+
+function isReplacementApkAsset(asset: GithubAsset): boolean {
+	return isApkAsset(asset) && (asset.name as string).startsWith(REPLACEMENT_APK_PREFIX);
+}
+
+export function parseReplacementRelease(
+	payload: unknown,
+	{ allowAnyApk = false }: ParseReplacementReleaseOptions = {},
+): ReplacementRelease | null {
 	if (!payload || typeof payload !== 'object') return null;
 
 	const release = payload as GithubRelease;
@@ -83,13 +119,8 @@ export function parseReplacementRelease(payload: unknown): ReplacementRelease | 
 	}
 	if (!Array.isArray(release.assets)) return null;
 
-	const apk = (release.assets as GithubAsset[]).find(
-		asset =>
-			typeof asset?.name === 'string' &&
-			asset.name.startsWith(REPLACEMENT_APK_PREFIX) &&
-			asset.name.endsWith('.apk') &&
-			isAllowedApkUrl(asset.browser_download_url),
-	);
+	const assets = release.assets as GithubAsset[];
+	const apk = assets.find(isReplacementApkAsset) ?? (allowAnyApk ? assets.find(isApkAsset) : undefined);
 
 	return apk ? { releaseUrl: release.html_url, apkUrl: apk.browser_download_url as string } : null;
 }
@@ -111,13 +142,16 @@ function parsePersistedActivation(value: unknown): ReplacementRelease | null {
 		: null;
 }
 
-export async function detectReplacementRelease(
-	targetStorage: ReplacementReleaseStorage = storage,
-	fetcher: Fetcher = fetch,
+export async function detectReplacementRelease({
+	storage: targetStorage = defaultStorage,
+	fetcher = fetch,
 	timeoutMs = REQUEST_TIMEOUT_MS,
-): Promise<ReplacementRelease | null> {
-	const persisted = readPersistedActivation(targetStorage);
-	if (persisted) return persisted;
+	testMode: useTestMode = false,
+}: DetectReplacementReleaseOptions = {}): Promise<ReplacementRelease | null> {
+	if (!useTestMode) {
+		const persisted = readPersistedActivation(targetStorage);
+		if (persisted) return persisted;
+	}
 
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -129,8 +163,8 @@ export async function detectReplacementRelease(
 		});
 		if (!response.ok) return null;
 
-		const release = parseReplacementRelease(await response.json());
-		if (release) targetStorage.set(ACTIVATION_STORAGE_KEY, JSON.stringify(release));
+		const release = parseReplacementRelease(await response.json(), { allowAnyApk: useTestMode });
+		if (release && !useTestMode) targetStorage.set(ACTIVATION_STORAGE_KEY, JSON.stringify(release));
 		return release;
 	} catch {
 		return null;
@@ -139,11 +173,46 @@ export async function detectReplacementRelease(
 	}
 }
 
-export function getReplacementReleaseForSession(): Promise<ReplacementRelease | null> {
-	if (Platform.OS !== 'android' || appApplicationId !== LEGACY_ANDROID_APPLICATION_ID) {
-		return Promise.resolve(null);
+/** The notice only ever applies to the final legacy Android build. */
+export function isLegacySunsetTarget(): boolean {
+	return Platform.OS === 'android' && appApplicationId === LEGACY_ANDROID_APPLICATION_ID;
+}
+
+export function isTestModeEnabled(): boolean {
+	if (testMode === undefined) {
+		try {
+			testMode = defaultStorage.getString(TEST_MODE_STORAGE_KEY) === 'true';
+		} catch {
+			testMode = false;
+		}
 	}
-	if (!sessionCheck) sessionCheck = detectReplacementRelease();
+	return testMode;
+}
+
+export function setTestModeEnabled(enabled: boolean): void {
+	if (isTestModeEnabled() === enabled) return;
+
+	testMode = enabled;
+	try {
+		defaultStorage.set(TEST_MODE_STORAGE_KEY, enabled ? 'true' : 'false');
+	} catch {
+		// Best effort. The in-memory value still applies to this session.
+	}
+
+	sessionCheck = undefined;
+	testModeListeners.forEach(listener => listener());
+}
+
+export function subscribeToTestMode(listener: () => void): () => void {
+	testModeListeners.add(listener);
+	return (): void => {
+		testModeListeners.delete(listener);
+	};
+}
+
+export function getReplacementReleaseForSession(): Promise<ReplacementRelease | null> {
+	if (!isLegacySunsetTarget()) return Promise.resolve(null);
+	if (!sessionCheck) sessionCheck = detectReplacementRelease({ testMode: isTestModeEnabled() });
 	return sessionCheck;
 }
 
@@ -151,20 +220,45 @@ export function useReplacementRelease(): {
 	replacementRelease: ReplacementRelease | null;
 	isReplacementAvailable: boolean;
 } {
-	const [replacementRelease, setReplacementRelease] = useState<ReplacementRelease | null>(null);
+	const [detection, setDetection] = useState<DetectionResult | null>(null);
+	const isTestMode = useSyncExternalStore(subscribeToTestMode, isTestModeEnabled);
 
 	useEffect(() => {
 		let mounted = true;
 		void getReplacementReleaseForSession().then(release => {
-			if (mounted) setReplacementRelease(release);
+			if (mounted) setDetection({ testMode: isTestMode, release });
 		});
-		return () => {
+		return (): void => {
 			mounted = false;
 		};
-	}, []);
+	}, [isTestMode]);
+
+	// Detections from the previous mode are dropped so the banner tracks the toggle immediately.
+	const replacementRelease = detection?.testMode === isTestMode ? detection.release : null;
 
 	return {
 		replacementRelease,
 		isReplacementAvailable: replacementRelease !== null,
+	};
+}
+
+/**
+ * Hidden settings toggle so QA can exercise the sunset notice before the replacement APK is published.
+ */
+export function useReplacementReleaseTestMode(): {
+	isTestModeAvailable: boolean;
+	isTestModeEnabled: boolean;
+	toggleTestMode: () => void;
+} {
+	const enabled = useSyncExternalStore(subscribeToTestMode, isTestModeEnabled);
+
+	const toggleTestMode = useCallback(() => {
+		setTestModeEnabled(!enabled);
+	}, [enabled]);
+
+	return {
+		isTestModeAvailable: isLegacySunsetTarget(),
+		isTestModeEnabled: enabled,
+		toggleTestMode,
 	};
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -38,6 +38,8 @@
 		"navigationAnimation": "Navigation Animation",
 		"autoAuth": "Auto Auth",
 		"showOnboarding": "Show Onboarding",
+		"legacySunsetTestMode": "Sunset Notice Test Mode",
+		"legacySunsetTestModeDescription": "Show the migration notice using the latest published release APK.",
 		"wipePubkyRing": "Wipe Pubky Ring",
 		"wipeConfirmTitle": "Are you sure?",
 		"wipeConfirmMessage": "This action will erase all Pubky Ring data and cannot be undone.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -38,6 +38,8 @@
 		"navigationAnimation": "Animación de la navegación",
 		"autoAuth": "Autenticación automática",
 		"showOnboarding": "Mostrar incorporación",
+		"legacySunsetTestMode": "Modo de prueba del aviso de migración",
+		"legacySunsetTestModeDescription": "Muestra el aviso de migración usando el APK de la última versión publicada.",
 		"wipePubkyRing": "Limpiar el anillo pubis",
 		"wipeConfirmTitle": "¿Está seguro?",
 		"wipeConfirmMessage": "Esta acción borrará todos los datos de Pubky Ring y no podrá deshacerse.",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -25,6 +25,7 @@ import { BodyMSBText, BodyMText, BodySText, CaptionText } from '../theme/typogra
 import { setOnMigrationComplete } from '../utils/actions/migrateAction.ts';
 import SafeAreaView from '../components/SafeAreaView.tsx';
 import { Qrcode, Scan } from '../icons/index.ts';
+import { useReplacementReleaseTestMode } from '../hooks/useReplacementRelease.ts';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
 
@@ -39,6 +40,7 @@ const SettingsScreen = ({ navigation, route }: Props): ReactElement => {
 	const hasPubkys = pubkyKeys.length > 0;
 	const [enableAutoAuth, setEnableAutoAuth] = useState(autoAuth);
 	const { showScanner } = useInputHandler({});
+	const { isTestModeAvailable, isTestModeEnabled, toggleTestMode } = useReplacementReleaseTestMode();
 
 	const getThemeDisplayText = useCallback(
 		(theme: ETheme) => {
@@ -223,6 +225,26 @@ const SettingsScreen = ({ navigation, route }: Props): ReactElement => {
 					</ThemedView>
 				)}
 
+				{showSecretSettings && isTestModeAvailable && (
+					<ThemedView style={styles.section} colorName="buttonBackground">
+						<TouchableOpacity
+							testID="LegacySunsetTestModeToggle"
+							onPress={toggleTestMode}
+							style={styles.testModeRow}
+						>
+							<View style={styles.testModeLabel}>
+								<BodyMSBText>{t('settings.legacySunsetTestMode')}</BodyMSBText>
+								<BodySText colorName="textTertiary">
+									{t('settings.legacySunsetTestModeDescription')}
+								</BodySText>
+							</View>
+							<View style={styles.switchContainer}>
+								<Switch value={isTestModeEnabled} onValueChange={toggleTestMode} />
+							</View>
+						</TouchableOpacity>
+					</ThemedView>
+				)}
+
 				{showSecretSettings && (
 					<ThemedView style={styles.section} colorName="buttonBackground">
 						<TouchableOpacity onPress={handleWipePubkyRing} style={styles.navigationAnimationButton}>
@@ -292,6 +314,20 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 16,
 		height: 60,
 		width: '100%',
+	},
+	testModeRow: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		gap: 12,
+		paddingHorizontal: 16,
+		paddingVertical: 12,
+		minHeight: 60,
+		width: '100%',
+	},
+	testModeLabel: {
+		flex: 1,
+		gap: 2,
 	},
 	buttonContainer: {
 		flexDirection: 'row',


### PR DESCRIPTION
## Summary

- add a hidden settings toggle, `Sunset Notice Test Mode`, so QA can exercise the legacy Android sunset banner and sheet before the replacement `app.pubkyring` APK is published
- when the toggle is on, release detection accepts the latest published release APK of any name instead of requiring the `pubky-ring-app.pubkyring-*.apk` asset
- keep every other condition intact: Android only, legacy `to.pubky.ring` package only, non draft, non prerelease, release URL restricted to `github.com/pubky/pubky-ring/releases/`, APK host restricted to `github.com` or `objects.githubusercontent.com`

## Why

Follow up to #341. The banner is dormant until the replacement release exists, so today there is nothing for QA to test against. This makes the real detection path testable against the current `v1.16` release without weakening any of the production gates.

## How it works

- toggle lives in the secret settings section of Settings, and is only rendered on the legacy Android build where the notice can apply
- state is stored in MMKV under `legacySunset.testMode`, outside Redux, so it survives a wipe and stays with the rest of the sunset state
- test mode never reads or writes the persisted activation (`legacySunset.replacementRelease`), so it cannot leave a production install permanently activated
- toggling resets the per session detection and notifies subscribers, so the banner appears or disappears without an app restart
- when both APKs are present, the replacement APK still wins

## QA notes

- the toggle only appears in the legacy `to.pubky.ring` Android build, reached through the secret settings entry
- network access is required, the toggle exercises the real GitHub release lookup rather than faking a result
- with test mode on, `Signed APK` opens the current legacy release APK and `Google Play` opens the `app.pubkyring` listing, which 404s until the new app is published
- turn the toggle off to confirm the banner disappears

## Verification

- `yarn test --runInBand` (40/40)
- `yarn typecheck`
- `yarn lint` on the changed files, one pre-existing `no-void` warning carried over from the original hook
- `yarn format:check`, only the pre-existing unrelated `src/components/ProfileAvatar.tsx` still fails
- JavaScript only change, no native code touched
