### PR TITLE
test(e2e): set e2e flows order

### DIFF
--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,4 +1,17 @@
 appId: ${APP_ID}
 flows:
   - flows/*.yaml
+executionOrder:
+  continueOnFailure: true
+  flowsOrder:
+    - onboarding
+    - delete-pubky
+    - create-pubky-default-homeserver
+    - create-pubky-and-authorize
+    - backup-pubky
+    - import-pubky-mnemonic
+    - migrate-keys
+    - deeplink-replaces-backup-sheet
+    # Keep the native file-picker flow last to avoid simulator issues in CI right after
+    - backup-and-import-file
 testOutputDir: .maestro/results

--- a/.maestro/shared/authorize.yaml
+++ b/.maestro/shared/authorize.yaml
@@ -4,6 +4,15 @@ appId: ${APP_ID}
     file: open-link.yaml
     env:
       URL: ${AUTH_URL}
+- runFlow:
+    when:
+      notVisible:
+        id: ConfirmAuthAuthorizeButton
+    commands:
+      - runFlow:
+          file: open-link.yaml
+          env:
+            URL: ${AUTH_URL}
 - extendedWaitUntil:
     visible:
       id: ConfirmAuthAuthorizeButton

--- a/.maestro/shared/close-sheet.yaml
+++ b/.maestro/shared/close-sheet.yaml
@@ -1,7 +1,6 @@
 appId: ${APP_ID}
+# Close any open sheet by tapping outside/above the sheet
 ---
-- swipe:
-    start: 50%, 17%
-    end: 50%, 95%
-    duration: 700
+- tapOn:
+    point: 50%,8%
 - waitForAnimationToEnd

--- a/src/components/CircularProgressBar.tsx
+++ b/src/components/CircularProgressBar.tsx
@@ -1,5 +1,12 @@
-import React, { memo, useEffect, useRef, useState } from 'react';
+import React, { memo, useEffect } from 'react';
 import Svg, { Circle } from 'react-native-svg';
+import Animated, {
+	Easing,
+	cancelAnimation,
+	useAnimatedProps,
+	useSharedValue,
+	withTiming,
+} from 'react-native-reanimated';
 
 type CircularProgressBarProps = {
 	duration?: number;
@@ -10,49 +17,34 @@ type CircularProgressBarProps = {
 	drain?: boolean;
 };
 
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
 const CircularProgressBar = ({
 	duration = 20000,
 	size = 24,
-	strokeWidth = 2,
-	unfilledColor = '#333333',
+	strokeWidth = 1.5,
+	unfilledColor = 'transparent',
 	filledColor = '#FFFFFF',
 	drain = false,
 }: CircularProgressBarProps): React.ReactElement => {
-	const [progress, setProgress] = useState(drain ? 1 : 0);
-	const animationFrame = useRef<number | null>(null);
+	const progress = useSharedValue(drain ? 1 : 0);
 	const radius = (size - strokeWidth) / 2;
 	const center = size / 2;
 	const circumference = 2 * Math.PI * radius;
-	const strokeDashoffset = circumference * (1 - progress);
+
+	const animatedProps = useAnimatedProps(() => ({
+		strokeDashoffset: (drain ? -1 : 1) * circumference * (1 - progress.value),
+	}));
 
 	useEffect(() => {
-		const startTime = Date.now();
-		const safeDuration = Math.max(duration, 1);
-
-		setProgress(drain ? 1 : 0);
-
-		const updateProgress = (): void => {
-			const elapsed = Date.now() - startTime;
-			const nextProgress = Math.min(elapsed / safeDuration, 1);
-
-			setProgress(drain ? 1 - nextProgress : nextProgress);
-
-			if (nextProgress >= 1) {
-				return;
-			}
-
-			animationFrame.current = requestAnimationFrame(updateProgress);
-		};
-
-		animationFrame.current = requestAnimationFrame(updateProgress);
+		cancelAnimation(progress);
+		progress.value = drain ? 1 : 0;
+		progress.value = withTiming(drain ? 0 : 1, { duration, easing: Easing.linear });
 
 		return (): void => {
-			if (animationFrame.current !== null) {
-				cancelAnimationFrame(animationFrame.current);
-				animationFrame.current = null;
-			}
+			cancelAnimation(progress);
 		};
-	}, [duration, drain]);
+	}, [duration, drain, progress]);
 
 	return (
 		<Svg
@@ -71,7 +63,7 @@ const CircularProgressBar = ({
 				strokeWidth={strokeWidth}
 				fill="none"
 			/>
-			<Circle
+			<AnimatedCircle
 				cx={center}
 				cy={center}
 				r={radius}
@@ -80,7 +72,8 @@ const CircularProgressBar = ({
 				fill="none"
 				strokeLinecap="round"
 				strokeDasharray={`${circumference} ${circumference}`}
-				strokeDashoffset={strokeDashoffset}
+				strokeDashoffset={0}
+				animatedProps={animatedProps}
 			/>
 		</Svg>
 	);

--- a/src/screens/ConfirmAuth.tsx
+++ b/src/screens/ConfirmAuth.tsx
@@ -181,7 +181,7 @@ const ConfirmAuth = ({ route }: NativeStackScreenProps<AuthStackParamList, 'Conf
 
 	const headerProgress =
 		Platform.OS === 'android' && !isAuthorized ? (
-			<CircularProgressBar duration={CONFIRM_AUTH_TIMEOUT_MS} size={20} drain={true} />
+			<CircularProgressBar duration={CONFIRM_AUTH_TIMEOUT_MS} size={24} drain={true} />
 		) : undefined;
 
 	return (


### PR DESCRIPTION
## Summary

Stabilize Maestro E2E runs across iOS and Android.

- Enforce deterministic Maestro flow ordering so native file-picker tests run last.
- Harden auth deep-link handling in E2E by retrying the deep link if the auth sheet does not appear.
- Improve sheet dismissal in shared Maestro flows.
- Move the circular auth countdown from JS `requestAnimationFrame` state updates to Reanimated, reducing UI churn during Maestro interactions.
