### PR TITLE
feat: support direct signup deeplinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Pubky Ring accepts input via deeplinks, QR code scanning, and clipboard pasting.
 |--------|--------|------------|
 | Auth | `pubkyauth:///?relay={url}&secret={secret}&caps={caps}` | `relay`: relay URL, `secret`: secret key, `caps`: comma-separated capabilities |
 | Sign In | `pubkyring://signin?caps=...&secret=...&relay=...` | Same as Auth (converted internally) |
-| Signup | `pubkyring://signup?hs={homeserver}&st={signup_token}&relay=...&secret=...&caps=...` | `hs`: homeserver URL, `st`: invite/signup token |
+| Signup | `pubkyring://signup?hs={homeserver}&relay=...&secret=...&caps=...[&st={signup_token}]` | Creates an account and authorizes an app; `st` is optional |
+| Direct Signup | `pubkyauth://direct_signup?hs={homeserver}[&st={signup_token}]` | Creates an account without app authorization; `st` is optional |
+| Legacy Direct Signup | `pubkyauth://signup?hs={homeserver}[&st={signup_token}]` | Backward-compatible account creation without app authorization |
 | Session | `pubkyring://session?callback={callback_url}` | `callback`: URL-encoded callback URL |
 | Migrate | `pubkyring://migrate?index={n}&total={total}&key={key}` | `index`: 0-based frame index, `total`: frame count, `key`: mnemonic or secret key |
 

--- a/__tests__/inputParser.test.ts
+++ b/__tests__/inputParser.test.ts
@@ -21,6 +21,7 @@ const mnemonicPhraseToKeypairMock = Pubky.mnemonicPhraseToKeypair as jest.Mocked
 const getPublicKeyFromSecretKeyMock = Pubky.getPublicKeyFromSecretKey as jest.MockedFunction<
 	typeof Pubky.getPublicKeyFromSecretKey
 >;
+const homeserverPubkey = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
 
 describe('parseInput', () => {
 	beforeEach(() => {
@@ -129,7 +130,7 @@ describe('parseInput', () => {
 		const xSuccess = 'bitkit://signup/success?nonce=abc&next=home';
 		const rawInput =
 			'pubkyring://signup?' +
-			`hs=${encodeURIComponent('https://homeserver.example.com')}` +
+			`hs=${homeserverPubkey}` +
 			'&st=ABCD-1234-WXYZ' +
 			`&relay=${encodeURIComponent('wss://relay.example.com')}` +
 			'&secret=secret-value' +
@@ -143,7 +144,7 @@ describe('parseInput', () => {
 		expect(parsed.data).toEqual({
 			action: InputAction.Signup,
 			params: {
-				homeserver: 'https://homeserver.example.com',
+				homeserver: homeserverPubkey,
 				inviteCode: 'ABCD-1234-WXYZ',
 				relay: 'wss://relay.example.com',
 				secret: 'secret-value',
@@ -154,6 +155,57 @@ describe('parseInput', () => {
 					xCancel: undefined,
 					xSource: 'Bitkit',
 				},
+			},
+		});
+	});
+
+	it('parses direct signup deeplinks without auth parameters', async () => {
+		const rawInput =
+			'pubkyauth://direct_signup?' +
+			`hs=${homeserverPubkey}` +
+			'&st=ABCD-1234-WXYZ';
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parsed.action).toBe(InputAction.DirectSignup);
+		expect(parsed.data).toEqual({
+			action: InputAction.DirectSignup,
+			params: {
+				homeserver: homeserverPubkey,
+				inviteCode: 'ABCD-1234-WXYZ',
+				xCallback: undefined,
+			},
+		});
+	});
+
+	it('parses direct signup deeplinks without signup tokens', async () => {
+		const rawInput = `pubkyauth://direct_signup?hs=${homeserverPubkey}`;
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parsed.action).toBe(InputAction.DirectSignup);
+		expect(parsed.data).toEqual({
+			action: InputAction.DirectSignup,
+			params: {
+				homeserver: homeserverPubkey,
+				inviteCode: '',
+				xCallback: undefined,
+			},
+		});
+	});
+
+	it('routes legacy signup deeplinks without auth parameters to direct signup', async () => {
+		const rawInput = `pubkyauth://signup?hs=${homeserverPubkey}&st=ABCD-1234-WXYZ`;
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parsed.action).toBe(InputAction.DirectSignup);
+		expect(parsed.data).toEqual({
+			action: InputAction.DirectSignup,
+			params: {
+				homeserver: homeserverPubkey,
+				inviteCode: 'ABCD-1234-WXYZ',
+				xCallback: undefined,
 			},
 		});
 	});

--- a/__tests__/inputRouter.test.ts
+++ b/__tests__/inputRouter.test.ts
@@ -10,7 +10,7 @@ import { InputAction, ParsedInput } from '../src/utils/inputParser';
 import { handleAuthAction } from '../src/utils/actions/authAction';
 import { handleImportAction } from '../src/utils/actions/importAction';
 import { handleMigrateAction } from '../src/utils/actions/migrateAction';
-import { handleSignupAction } from '../src/utils/actions/signupAction';
+import { handleDirectSignupAction, handleSignupAction } from '../src/utils/actions/signupAction';
 import { handleInviteAction } from '../src/utils/actions/inviteAction';
 import { handleSessionAction } from '../src/utils/actions/sessionAction';
 import { showSheet } from '../src/sheets/sheetNavigation';
@@ -56,6 +56,7 @@ jest.mock('../src/utils/actions/migrateAction', () => ({
 jest.mock('../src/utils/actions/signupAction', () => ({
 	__esModule: true,
 	handleSignupAction: jest.fn(),
+	handleDirectSignupAction: jest.fn(),
 }));
 
 jest.mock('../src/utils/actions/inviteAction', () => ({
@@ -77,6 +78,9 @@ const handleAuthActionMock = handleAuthAction as jest.MockedFunction<typeof hand
 const handleImportActionMock = handleImportAction as jest.MockedFunction<typeof handleImportAction>;
 const handleMigrateActionMock = handleMigrateAction as jest.MockedFunction<typeof handleMigrateAction>;
 const handleSignupActionMock = handleSignupAction as jest.MockedFunction<typeof handleSignupAction>;
+const handleDirectSignupActionMock = handleDirectSignupAction as jest.MockedFunction<
+	typeof handleDirectSignupAction
+>;
 const handleInviteActionMock = handleInviteAction as jest.MockedFunction<typeof handleInviteAction>;
 const handleSessionActionMock = handleSessionAction as jest.MockedFunction<typeof handleSessionAction>;
 const showSheetMock = showSheet as jest.MockedFunction<typeof showSheet>;
@@ -152,7 +156,7 @@ describe('routeInput', () => {
 			data: {
 				action: InputAction.Signup,
 				params: {
-					homeserver: 'https://homeserver.example.com',
+					homeserver: '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty',
 					inviteCode: 'ABCD-1234-WXYZ',
 					relay: 'wss://relay.example.com',
 					secret: 'secret',
@@ -165,6 +169,24 @@ describe('routeInput', () => {
 				success: true,
 				action: InputAction.Signup,
 				pubky: 'pubky-signed-up',
+				message: 'router.signupSuccessful',
+			},
+		},
+		{
+			action: InputAction.DirectSignup,
+			data: {
+				action: InputAction.DirectSignup,
+				params: {
+					homeserver: '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty',
+					inviteCode: 'ABCD-1234-WXYZ',
+				},
+			},
+			handler: handleDirectSignupActionMock,
+			handlerValue: 'pubky-direct-signed-up',
+			expectedValue: {
+				success: true,
+				action: InputAction.DirectSignup,
+				pubky: 'pubky-direct-signed-up',
 				message: 'router.signupSuccessful',
 			},
 		},
@@ -287,6 +309,7 @@ describe('routeInput', () => {
 		expect(handleImportActionMock).not.toHaveBeenCalled();
 		expect(handleMigrateActionMock).not.toHaveBeenCalled();
 		expect(handleSignupActionMock).not.toHaveBeenCalled();
+		expect(handleDirectSignupActionMock).not.toHaveBeenCalled();
 		expect(handleInviteActionMock).not.toHaveBeenCalled();
 		expect(handleSessionActionMock).not.toHaveBeenCalled();
 
@@ -304,6 +327,7 @@ describe('input routing helpers', () => {
 	it('identifies actions that need network access', () => {
 		expect(actionRequiresNetwork(InputAction.Auth)).toBe(true);
 		expect(actionRequiresNetwork(InputAction.Signup)).toBe(true);
+		expect(actionRequiresNetwork(InputAction.DirectSignup)).toBe(true);
 		expect(actionRequiresNetwork(InputAction.Invite)).toBe(true);
 		expect(actionRequiresNetwork(InputAction.Session)).toBe(true);
 		expect(actionRequiresNetwork(InputAction.Import)).toBe(false);

--- a/__tests__/signupAction.test.ts
+++ b/__tests__/signupAction.test.ts
@@ -1,0 +1,240 @@
+import { InputAction } from '../src/utils/inputParser';
+import { handleDirectSignupAction, handleSignupAction } from '../src/utils/actions/signupAction';
+import { handleAuthAction } from '../src/utils/actions/authAction';
+import { hideSheet } from '../src/sheets/sheetNavigation';
+import { savePubky, signUpToHomeserver } from '../src/utils/pubky';
+import { getSignedUpPubkysFromStore } from '../src/utils/store-helpers';
+import { EBackupPreference } from '../src/types/pubky';
+
+jest.mock('../src/i18n', () => ({
+	__esModule: true,
+	default: {
+		t: (key: string) => key,
+	},
+}));
+
+jest.mock('@synonymdev/react-native-pubky', () => ({
+	__esModule: true,
+	generateMnemonicPhraseAndKeypair: jest.fn(async () => {
+		const { ok } = require('@synonymdev/result');
+		return ok({
+			mnemonic: 'one two three four five six seven eight nine ten eleven twelve',
+			secret_key: 'secret-key',
+			public_key: 'pubky-created',
+		});
+	}),
+}));
+
+jest.mock('@synonymdev/react-native-toast', () => ({
+	__esModule: true,
+	showToast: jest.fn(),
+}));
+
+jest.mock('../src/utils/pubky', () => ({
+	__esModule: true,
+	savePubky: jest.fn(async () => {
+		const { ok } = require('@synonymdev/result');
+		return ok('pubky-created');
+	}),
+	signUpToHomeserver: jest.fn(async () => {
+		const { ok } = require('@synonymdev/result');
+		return ok({ session_secret: 'session-secret' });
+	}),
+}));
+
+jest.mock('../src/utils/helpers', () => ({
+	__esModule: true,
+	checkNetworkConnection: jest.fn(async () => true),
+}));
+
+jest.mock('../src/utils/xCallback', () => ({
+	__esModule: true,
+	openXError: jest.fn(),
+}));
+
+jest.mock('../src/store/slices/pubkysSlice', () => ({
+	__esModule: true,
+	addProcessing: jest.fn((payload: { pubky: string }) => ({ type: 'pubky/addProcessing', payload })),
+	removeProcessing: jest.fn((payload: { pubky: string }) => ({ type: 'pubky/removeProcessing', payload })),
+}));
+
+jest.mock('../src/store/slices/uiSlice', () => ({
+	__esModule: true,
+	setLoadingModalError: jest.fn((payload: unknown) => ({ type: 'ui/setLoadingModalError', payload })),
+}));
+
+jest.mock('../src/utils/signupErrors', () => ({
+	__esModule: true,
+	getSignupTokenErrorModalFields: jest.fn(() => ({})),
+}));
+
+jest.mock('../src/utils/store-helpers', () => ({
+	__esModule: true,
+	getPubkyDataFromStore: jest.fn(),
+	getPubkyKeyBySignupTokenFromStore: jest.fn(() => undefined),
+	getSignedUpPubkysFromStore: jest.fn(() => ({})),
+}));
+
+jest.mock('../src/utils/actions/authAction', () => ({
+	__esModule: true,
+	handleAuthAction: jest.fn(async () => {
+		const { ok } = require('@synonymdev/result');
+		return ok('authorized');
+	}),
+}));
+
+jest.mock('../src/sheets/sheetNavigation', () => ({
+	__esModule: true,
+	hideSheet: jest.fn(),
+}));
+
+const handleAuthActionMock = handleAuthAction as jest.MockedFunction<typeof handleAuthAction>;
+const hideSheetMock = hideSheet as jest.MockedFunction<typeof hideSheet>;
+const savePubkyMock = savePubky as jest.MockedFunction<typeof savePubky>;
+const signUpToHomeserverMock = signUpToHomeserver as jest.MockedFunction<typeof signUpToHomeserver>;
+const getSignedUpPubkysFromStoreMock = getSignedUpPubkysFromStore as jest.MockedFunction<
+	typeof getSignedUpPubkysFromStore
+>;
+const homeserverPubkey = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
+
+describe('handleSignupAction', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('signs up directly without delivering auth when auth params are absent', async () => {
+		const dispatch = jest.fn();
+		const setAddPubkyScreen = jest.fn();
+
+		const result = await handleDirectSignupAction(
+			{
+				action: InputAction.DirectSignup,
+				params: {
+					homeserver: homeserverPubkey,
+					inviteCode: 'ABCD-1234-WXYZ',
+				},
+			},
+			{ dispatch, setAddPubkyScreen },
+		);
+
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) {
+			expect(result.value).toBe('pubky-created');
+		}
+		expect(setAddPubkyScreen).toHaveBeenCalledWith({ screen: 'Loading' });
+		expect(savePubkyMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				pubky: 'pubky-created',
+				secretKey: 'secret-key',
+				signupToken: 'ABCD-1234-WXYZ',
+				dispatch,
+			}),
+		);
+		expect(signUpToHomeserverMock).toHaveBeenCalledWith({
+			pubky: 'pubky-created',
+			secretKey: 'secret-key',
+			homeserver: homeserverPubkey,
+			signupToken: 'ABCD-1234-WXYZ',
+			dispatch,
+		});
+		expect(hideSheetMock).toHaveBeenCalledWith('add-pubky');
+		expect(handleAuthActionMock).not.toHaveBeenCalled();
+	});
+
+	it('signs up directly without a signup token when st is absent', async () => {
+		const dispatch = jest.fn();
+		const setAddPubkyScreen = jest.fn();
+
+		const result = await handleDirectSignupAction(
+			{
+				action: InputAction.DirectSignup,
+				params: {
+					homeserver: homeserverPubkey,
+					inviteCode: '',
+				},
+			},
+			{ dispatch, setAddPubkyScreen },
+		);
+
+		expect(result.isOk()).toBe(true);
+		expect(signUpToHomeserverMock).toHaveBeenCalledWith({
+			pubky: 'pubky-created',
+			secretKey: 'secret-key',
+			homeserver: homeserverPubkey,
+			signupToken: '',
+			dispatch,
+		});
+		expect(handleAuthActionMock).not.toHaveBeenCalled();
+	});
+
+	it('delivers auth after signup when auth params are present', async () => {
+		const dispatch = jest.fn();
+		const setAddPubkyScreen = jest.fn();
+		const xCallback = { xSuccess: 'bitkit://signup/success' };
+
+		const result = await handleSignupAction(
+			{
+				action: InputAction.Signup,
+				params: {
+					homeserver: homeserverPubkey,
+					inviteCode: 'ABCD-1234-WXYZ',
+					relay: 'wss://relay.example.com',
+					secret: 'auth-secret',
+					caps: ['pubky.app:read', 'pubky.app:write'],
+					xCallback,
+				},
+			},
+			{ dispatch, setAddPubkyScreen },
+		);
+
+		expect(result.isOk()).toBe(true);
+		expect(handleAuthActionMock).toHaveBeenCalledWith(
+			{
+				action: InputAction.Auth,
+				params: {
+					relay: 'wss://relay.example.com',
+					secret: 'auth-secret',
+					caps: ['pubky.app:read', 'pubky.app:write'],
+					xCallback,
+				},
+				rawUrl:
+					'pubkyauth:///?relay=wss%3A%2F%2Frelay.example.com&secret=auth-secret&caps=pubky.app%3Aread%2Cpubky.app%3Awrite',
+			},
+			{ dispatch, setAddPubkyScreen, pubky: 'pubky-created', isDeeplink: false },
+		);
+	});
+
+	it('keeps the signup error visible for direct signup failures even when existing pubkys are present', async () => {
+		const { err } = require('@synonymdev/result');
+		const dispatch = jest.fn();
+		const setAddPubkyScreen = jest.fn();
+		signUpToHomeserverMock.mockResolvedValueOnce(err(new Error('Invite code was already used')));
+		getSignedUpPubkysFromStoreMock.mockReturnValueOnce({
+			'pubky-existing': {
+				name: '',
+				image: '',
+				homeserver: homeserverPubkey,
+				signedUp: true,
+				sessions: [],
+				signupToken: '',
+				backupPreference: EBackupPreference.encryptedFile,
+				isBackedUp: false,
+			},
+		});
+
+		const result = await handleDirectSignupAction(
+			{
+				action: InputAction.DirectSignup,
+				params: {
+					homeserver: homeserverPubkey,
+					inviteCode: 'ABCD-1234-WXYZ',
+				},
+			},
+			{ dispatch, setAddPubkyScreen },
+		);
+
+		expect(result.isErr()).toBe(true);
+		expect(hideSheetMock).not.toHaveBeenCalled();
+		expect(handleAuthActionMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/screens/AddPubkyScanner.tsx
+++ b/src/screens/AddPubkyScanner.tsx
@@ -32,7 +32,11 @@ const AddPubkyScanner = ({
 	const isAllowedAction = useCallback(
 		(action: InputAction): boolean => {
 			if (mode === 'signup') {
-				return action === InputAction.Signup || action === InputAction.Invite;
+				return (
+					action === InputAction.Signup ||
+					action === InputAction.DirectSignup ||
+					action === InputAction.Invite
+				);
 			}
 
 			return action === InputAction.Import;

--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -2,13 +2,14 @@
  * Signup Action Handler
  *
  * Handles signup deeplinks that create a new pubky and authorize with a service.
- * Format: pubkyauth://signup?hs={homeserver}&st={signup_token}&relay={relay}&secret={secret}&caps={capabilities}
+ * Format: pubkyauth://signup?hs={homeserver}&relay={relay}&secret={secret}&caps={capabilities}[&st={signup_token}]
+ * Direct format: pubkyauth://direct_signup?hs={homeserver}[&st={signup_token}]
  */
 
 import { Result, ok, err } from '@synonymdev/result';
 import { generateMnemonicPhraseAndKeypair } from '@synonymdev/react-native-pubky';
 import { showToast } from '@synonymdev/react-native-toast';
-import { InputAction, SignupParams } from '../inputParser';
+import { DirectSignupParams, InputAction, SignupParams } from '../inputParser';
 import { RoutedActionContext } from '../inputRouter';
 import { savePubky, signUpToHomeserver } from '../pubky';
 import { checkNetworkConnection } from '../helpers';
@@ -18,6 +19,7 @@ import { addProcessing, removeProcessing } from '../../store/slices/pubkysSlice'
 import { setLoadingModalError } from '../../store/slices/uiSlice';
 import { EBackupPreference } from '../../types/pubky';
 import { handleAuthAction } from './authAction';
+import type { AuthActionData } from './authAction';
 import { getSignupTokenErrorModalFields, LoadingErrorModalFields } from '../signupErrors';
 import i18n from '../../i18n';
 import { hideSheet } from '../../sheets/sheetNavigation.tsx';
@@ -32,6 +34,13 @@ type SignupActionData = {
 	action: InputAction.Signup;
 	params: SignupParams;
 };
+
+type DirectSignupActionData = {
+	action: InputAction.DirectSignup;
+	params: DirectSignupParams;
+};
+
+type SignupBaseActionData = SignupActionData | DirectSignupActionData;
 
 /**
  * Transitions the loading modal to error state via Redux
@@ -51,18 +60,31 @@ const showErrorState = (
 	);
 };
 
+const createSignupAuthData = (params: SignupParams): AuthActionData => {
+	const { relay, secret, xCallback } = params;
+
+	return {
+		action: InputAction.Auth,
+		params: { relay, secret, caps: params.caps, xCallback },
+		rawUrl: `pubkyauth:///?relay=${encodeURIComponent(relay)}&secret=${encodeURIComponent(
+			secret,
+		)}&caps=${encodeURIComponent(params.caps.join(','))}`,
+	};
+};
+
 /**
- * Handles signup action - creates a new pubky, signs up to homeserver, and initiates auth
+ * Handles signup flow - creates a new pubky, signs up to homeserver, and optionally initiates auth
  *
  * @returns The created pubky string on success
  */
-export const handleSignupAction = async (
-	data: SignupActionData,
+const handleSignup = async (
+	data: SignupBaseActionData,
 	context: RoutedActionContext,
+	authData?: AuthActionData,
 ): Promise<Result<string>> => {
 	const { dispatch } = context;
 	const { params } = data;
-	const { xCallback, homeserver, inviteCode, relay, secret, caps } = params;
+	const { xCallback, homeserver, inviteCode } = params;
 
 	const isOnline = await checkNetworkConnection({
 		dispatch,
@@ -85,16 +107,6 @@ export const handleSignupAction = async (
 	let secretKey: string | undefined;
 	let mnemonic: string | undefined;
 
-	const capsString = caps.join(',');
-	const authUrl = `pubkyauth:///?relay=${encodeURIComponent(relay)}&secret=${encodeURIComponent(
-		secret,
-	)}&caps=${encodeURIComponent(capsString)}`;
-	const authData = {
-		action: InputAction.Auth,
-		params: { relay, secret, caps, xCallback },
-		rawUrl: authUrl,
-	} as const;
-
 	// If a pubky already exists for this signup token (e.g. user is rescanning the
 	// same onboarding QR after a prior failure), reuse it instead of creating a new key.
 	const existingPubkyKey = getPubkyKeyBySignupTokenFromStore(inviteCode);
@@ -104,8 +116,10 @@ export const handleSignupAction = async (
 		isReusedPubky = true;
 
 		if (existingPubky?.signedUp) {
-			// Already signed up to homeserver — skip the loading modal and signup and forward to auth.
-			await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
+			// Already signed up to homeserver — skip the loading modal and signup.
+			if (authData) {
+				await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
+			}
 			return ok(pubky);
 		}
 	}
@@ -166,9 +180,11 @@ export const handleSignupAction = async (
 			const signedUpKeys = Object.keys(signedUpPubkys);
 
 			if (signedUpKeys.length > 0) {
-				// User has existing pubky(s) - forward to auth flow instead of showing error
-				hideSheet('add-pubky');
-				return await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
+				// User has existing pubky(s) - forward to auth flow instead of showing error when possible.
+				if (authData) {
+					hideSheet('add-pubky');
+					return await handleAuthAction(authData, { ...context, pubky, isDeeplink: false });
+				}
 			}
 
 			// No existing pubkys - show error as before
@@ -187,13 +203,15 @@ export const handleSignupAction = async (
 
 		hideSheet('add-pubky');
 
-		// Step 4: Trigger auth action with the new pubky
-		await handleAuthAction(authData, {
-			...context,
-			pubky,
-			// Don't treat as deeplink for redirect behavior since we want user to stay in app
-			isDeeplink: false,
-		});
+		// Step 4: Trigger auth action with the new pubky when the link includes auth parameters.
+		if (authData) {
+			await handleAuthAction(authData, {
+				...context,
+				pubky,
+				// Don't treat as deeplink for redirect behavior since we want user to stay in app
+				isDeeplink: false,
+			});
+		}
 
 		return ok(pubky);
 	} catch (error) {
@@ -208,4 +226,18 @@ export const handleSignupAction = async (
 			dispatch(removeProcessing({ pubky }));
 		}
 	}
+};
+
+export const handleSignupAction = async (
+	data: SignupActionData,
+	context: RoutedActionContext,
+): Promise<Result<string>> => {
+	return handleSignup(data, context, createSignupAuthData(data.params));
+};
+
+export const handleDirectSignupAction = async (
+	data: DirectSignupActionData,
+	context: RoutedActionContext,
+): Promise<Result<string>> => {
+	return handleSignup(data, context);
 };

--- a/src/utils/inputHandlerUtils.ts
+++ b/src/utils/inputHandlerUtils.ts
@@ -38,7 +38,11 @@ export const routeInputWithContext = async (
 
 	if (result.isErr()) {
 		// Skip toast for signup/invite actions - they handle errors via the loading modal
-		if (parsed.action === InputAction.Signup || parsed.action === InputAction.Invite) {
+		if (
+			parsed.action === InputAction.Signup ||
+			parsed.action === InputAction.DirectSignup ||
+			parsed.action === InputAction.Invite
+		) {
 			return;
 		}
 

--- a/src/utils/inputParser.ts
+++ b/src/utils/inputParser.ts
@@ -23,6 +23,7 @@ export enum InputAction {
 	Import = 'import',
 	Migrate = 'migrate',
 	Signup = 'signup',
+	DirectSignup = 'direct_signup',
 	Invite = 'invite',
 	Session = 'session',
 	HomeserverSignIn = 'homeserver_signin',
@@ -36,6 +37,13 @@ export interface SignupParams {
 	relay: string;
 	secret: string;
 	caps: string[];
+	xCallback?: XCallbackParams;
+}
+
+// Direct signup parameters extracted from direct_signup deeplinks
+export interface DirectSignupParams {
+	homeserver: string;
+	inviteCode: string;
 	xCallback?: XCallbackParams;
 }
 
@@ -92,6 +100,7 @@ export type ActionData =
 	| { action: InputAction.Import; params: ImportParams }
 	| { action: InputAction.Migrate; params: MigrateParams }
 	| { action: InputAction.Signup; params: SignupParams }
+	| { action: InputAction.DirectSignup; params: DirectSignupParams }
 	| { action: InputAction.Invite; params: InviteParams }
 	| { action: InputAction.Session; params: SessionParams }
 	| { action: InputAction.HomeserverSignIn; params: { url: string } }
@@ -228,7 +237,7 @@ export const extractXCallbackParams = (encodedQueryString: string): XCallbackPar
 
 /**
  * Parses signup deeplink parameters
- * Format: signup?hs={homeserver}&st={signup_token}&relay={relay_url}&secret={secret}&caps={capabilities}
+ * Format: signup?hs={homeserver}&relay={relay_url}&secret={secret}&caps={capabilities}[&st={signup_token}]
  *
  * `queryString` is the (possibly multi-pass-decoded) query for plain fields;
  * `encodedQueryString` is the original encoded query used for x-callback
@@ -237,12 +246,45 @@ export const extractXCallbackParams = (encodedQueryString: string): XCallbackPar
 const parseSignupParams = (queryString: string, encodedQueryString: string): SignupParams | null => {
 	try {
 		const params = new URLSearchParams(queryString);
+		const relay = params.get('relay');
+		const secret = params.get('secret');
+
+		if (!relay || !secret) {
+			return null;
+		}
+
 		return {
 			homeserver: decodeURIComponent(params.get('hs') || ''),
 			inviteCode: params.get('st') || '',
-			relay: decodeURIComponent(params.get('relay') || ''),
-			secret: params.get('secret') || '',
+			relay: decodeURIComponent(relay),
+			secret,
 			caps: (params.get('caps') || '').split(',').filter(Boolean),
+			xCallback: extractXCallbackParams(encodedQueryString),
+		};
+	} catch {
+		return null;
+	}
+};
+
+const hasSignupAuthParams = (queryString: string): boolean => {
+	const params = new URLSearchParams(queryString);
+	return Boolean(params.get('relay') && params.get('secret'));
+};
+
+/**
+ * Parses direct signup deeplink parameters
+ * Format: direct_signup?hs={homeserver_pubkey}[&st={signup_token}]
+ */
+const parseDirectSignupParams = (
+	queryString: string,
+	encodedQueryString: string,
+): DirectSignupParams | null => {
+	try {
+		const params = new URLSearchParams(queryString);
+
+		return {
+			homeserver: decodeURIComponent(params.get('hs') || ''),
+			inviteCode: params.get('st') || '',
 			xCallback: extractXCallbackParams(encodedQueryString),
 		};
 	} catch {
@@ -360,29 +402,58 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 	// Normalize: remove trailing slash before query string for known routes
 	if (urlWithoutProtocol.startsWith('signup/?'))
 		urlWithoutProtocol = urlWithoutProtocol.replace('signup/?', 'signup?');
+	if (urlWithoutProtocol.startsWith('direct_signup/?'))
+		urlWithoutProtocol = urlWithoutProtocol.replace('direct_signup/?', 'direct_signup?');
 	if (urlWithoutProtocol.startsWith('session/?'))
 		urlWithoutProtocol = urlWithoutProtocol.replace('session/?', 'session?');
 	if (urlWithoutProtocol.startsWith('signin/?'))
 		urlWithoutProtocol = urlWithoutProtocol.replace('signin/?', 'signin?');
 
-	// 1. Check for signup deeplink
-	// Format: pubkyring://signup?... or pubkyauth://signup?...
+	// 1. Check for direct signup deeplink
+	// Format: pubkyauth://direct_signup?...
 	// The signup token (st) is optional per the pubky 0.9.1 deep link spec —
 	// homeservers without invite requirements omit it.
-	if (urlWithoutProtocol.startsWith('signup?')) {
-		const queryString = urlWithoutProtocol.substring(7); // Remove "signup?"
-		const signupParams = parseSignupParams(queryString, rawEncodedQuery);
-		if (signupParams?.homeserver) {
+	if (urlWithoutProtocol.startsWith('direct_signup?')) {
+		const queryString = urlWithoutProtocol.substring('direct_signup?'.length);
+		const directSignupParams = parseDirectSignupParams(queryString, rawEncodedQuery);
+		if (directSignupParams?.homeserver) {
 			return {
-				action: InputAction.Signup,
-				data: { action: InputAction.Signup, params: signupParams },
+				action: InputAction.DirectSignup,
+				data: { action: InputAction.DirectSignup, params: directSignupParams },
 				source,
 				rawInput,
 			};
 		}
 	}
 
-	// 2. Check for session deeplink
+	// 2. Check for signup deeplink
+	// Format: pubkyring://signup?... or pubkyauth://signup?...
+	if (urlWithoutProtocol.startsWith('signup?')) {
+		const queryString = urlWithoutProtocol.substring('signup?'.length);
+		if (hasSignupAuthParams(queryString)) {
+			const signupParams = parseSignupParams(queryString, rawEncodedQuery);
+			if (signupParams?.homeserver) {
+				return {
+					action: InputAction.Signup,
+					data: { action: InputAction.Signup, params: signupParams },
+					source,
+					rawInput,
+				};
+			}
+		}
+
+		const directSignupParams = parseDirectSignupParams(queryString, rawEncodedQuery);
+		if (directSignupParams?.homeserver) {
+			return {
+				action: InputAction.DirectSignup,
+				data: { action: InputAction.DirectSignup, params: directSignupParams },
+				source,
+				rawInput,
+			};
+		}
+	}
+
+	// 3. Check for session deeplink
 	// Format: pubkyring://session?x-success={url} or pubkyring://session?callback={url}
 	if (urlWithoutProtocol.startsWith('session?')) {
 		const sessionParams = parseSessionParams(rawEncodedQuery);
@@ -396,7 +467,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		}
 	}
 
-	// 3. Check for signin deeplink (alternative auth format)
+	// 4. Check for signin deeplink (alternative auth format)
 	// Format: pubkyring://signin?caps=...&secret=...&relay=...
 	// Convert to pubkyauth:/// format for parsing
 	if (urlWithoutProtocol.startsWith('signin?')) {
@@ -404,7 +475,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		processedInput = `pubkyauth:///?${queryString}`;
 	}
 
-	// 4. Check for auth URL
+	// 5. Check for auth URL
 	// Format: pubkyauth:///...
 	const authResult = await parseAuthUrl(processedInput);
 	if (authResult.isOk()) {
@@ -434,7 +505,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 5. Check for invite code in URL
+	// 6. Check for invite code in URL
 	const inviteCode = parseInviteCodeFromUrl(processedInput);
 	if (inviteCode) {
 		// Extract x-callback params from the original encoded query so inner
@@ -448,7 +519,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 6. Check if it's a standalone invite code (XXXX-XXXX-XXXX format)
+	// 7. Check if it's a standalone invite code (XXXX-XXXX-XXXX format)
 	if (isValidInviteCode(urlWithoutProtocol)) {
 		return {
 			action: InputAction.Invite,
@@ -458,7 +529,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 7. Check for import data (recovery phrase or secret key)
+	// 8. Check for import data (recovery phrase or secret key)
 	const formatted = formatImportData(processedInput);
 	const importValidation = await validateImportData(formatted);
 	if (importValidation.isValid) {
@@ -476,7 +547,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 8. Quick check for recovery phrase pattern (12 words) even if validation failed
+	// 9. Quick check for recovery phrase pattern (12 words) even if validation failed
 	// This handles cases where the mnemonic might be valid but validation takes time
 	const words = formatted.trim().split(/\s+/);
 	if (words.length === 12) {
@@ -498,7 +569,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		}
 	}
 
-	// 9. Default to unknown
+	// 10. Default to unknown
 	return {
 		action: InputAction.Unknown,
 		data: { action: InputAction.Unknown, params: { rawData: processedInput } },
@@ -532,6 +603,12 @@ export const isSignupAction = (
 	data: ActionData,
 ): data is { action: InputAction.Signup; params: SignupParams } => {
 	return data.action === InputAction.Signup;
+};
+
+export const isDirectSignupAction = (
+	data: ActionData,
+): data is { action: InputAction.DirectSignup; params: DirectSignupParams } => {
+	return data.action === InputAction.DirectSignup;
 };
 
 export const isInviteAction = (

--- a/src/utils/inputRouter.ts
+++ b/src/utils/inputRouter.ts
@@ -15,6 +15,7 @@ import {
 	isImportAction,
 	isMigrateAction,
 	isSignupAction,
+	isDirectSignupAction,
 	isInviteAction,
 	isSessionAction,
 	isUnknownAction,
@@ -22,7 +23,7 @@ import {
 import { handleAuthAction } from './actions/authAction';
 import { handleImportAction } from './actions/importAction';
 import { handleMigrateAction } from './actions/migrateAction';
-import { handleSignupAction } from './actions/signupAction';
+import { handleDirectSignupAction, handleSignupAction } from './actions/signupAction';
 import { handleInviteAction } from './actions/inviteAction';
 import { handleSessionAction } from './actions/sessionAction';
 import i18n from '../i18n';
@@ -121,6 +122,18 @@ export const routeInput = async (
 				: err(getErrorMessage(result.error, i18n.t('errors.signupFailed')));
 		}
 
+		if (isDirectSignupAction(data)) {
+			const result = await handleDirectSignupAction(data, effectiveContext);
+			return result.isOk()
+				? ok({
+						success: true,
+						action: InputAction.DirectSignup,
+						pubky: result.value,
+						message: i18n.t('router.signupSuccessful'),
+					})
+				: err(getErrorMessage(result.error, i18n.t('errors.signupFailed')));
+		}
+
 		if (isInviteAction(data)) {
 			const result = await handleInviteAction(data, effectiveContext);
 			return result.isOk()
@@ -169,7 +182,13 @@ export const actionRequiresPubky = (action: InputAction): boolean => {
  * Determines if an action can proceed without network
  */
 export const actionRequiresNetwork = (action: InputAction): boolean => {
-	return [InputAction.Auth, InputAction.Signup, InputAction.Invite, InputAction.Session].includes(action);
+	return [
+		InputAction.Auth,
+		InputAction.Signup,
+		InputAction.DirectSignup,
+		InputAction.Invite,
+		InputAction.Session,
+	].includes(action);
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes https://github.com/pubky/pubky-ring/issues/351

- Add a separate `direct_signup` deeplink action for account creation without app authorization
- Route `pubkyauth://direct_signup?hs=...` to direct signup, with optional `st`
- Preserve compatibility for legacy `pubkyauth://signup?hs=...` links without auth params by routing them to direct signup
- Keep regular signup links with `relay`/`secret` on the existing signup+auth flow
- Update parser, router, scanner handling, and tests for the separate direct signup action

## Notes

This logic will be replaced in the future, see https://github.com/pubky/pubky-ring/issues/353

## Testing

- `yarn test --runInBand`
- `yarn typecheck`
- `yarn lint`