### PR TITLE
Use Pubky 0.10 grant auth bindings

### DIFF
--- a/__mocks__/@synonymdev/react-native-pubky.js
+++ b/__mocks__/@synonymdev/react-native-pubky.js
@@ -1,0 +1,12 @@
+const { err } = require('@synonymdev/result');
+
+module.exports = {
+	__esModule: true,
+	parseDeepLink: jest.fn(async () => err('not a deeplink')),
+	mnemonicPhraseToKeypair: jest.fn(async () => err('not a mnemonic')),
+	getPublicKeyFromSecretKey: jest.fn(async () => err('not a secret key')),
+	generateMnemonicPhraseAndKeypair: jest.fn(async () =>
+		err('Mocked react-native-pubky.generateMnemonicPhraseAndKeypair was not configured for this test'),
+	),
+	signOut: jest.fn(async () => err('Mocked react-native-pubky.signOut was not configured for this test')),
+};

--- a/__tests__/authAction.test.ts
+++ b/__tests__/authAction.test.ts
@@ -1,0 +1,145 @@
+import { ok, err } from '@synonymdev/result';
+import { parseDeepLink } from '@synonymdev/react-native-pubky';
+import { createConfirmAuthPayload } from '../src/utils/actions/authAction';
+import { InputAction } from '../src/utils/inputParser';
+
+jest.mock('@synonymdev/react-native-pubky');
+
+jest.mock('../src/i18n', () => ({
+	__esModule: true,
+	default: {
+		t: (key: string) => key,
+	},
+}));
+
+jest.mock('@synonymdev/react-native-toast', () => ({
+	__esModule: true,
+	showToast: jest.fn(),
+}));
+
+jest.mock('../src/sheets/sheetNavigation.tsx', () => ({
+	__esModule: true,
+	showSheet: jest.fn(),
+}));
+
+jest.mock('../src/utils/pubky', () => ({
+	__esModule: true,
+	performAuth: jest.fn(),
+}));
+
+jest.mock('../src/utils/store-helpers', () => ({
+	__esModule: true,
+	getAutoAuthFromStore: jest.fn(() => false),
+}));
+
+jest.mock('../src/utils/xCallback', () => ({
+	__esModule: true,
+	openXSuccess: jest.fn(),
+	openXError: jest.fn(),
+}));
+
+const parseDeepLinkMock = parseDeepLink as jest.MockedFunction<typeof parseDeepLink>;
+
+describe('createConfirmAuthPayload', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('parses grant auth URLs with the Pubky deeplink parser', async () => {
+		const xCallback = { xSuccess: 'bitkit://auth/success' };
+		parseDeepLinkMock.mockResolvedValueOnce(
+			ok({
+				scheme: 'pubkyauth',
+				kind: 'signin_grant',
+				url: 'pubkyauth://signin_grant?secret=auth-secret',
+				relay: 'wss://relay.example.com',
+				secret: 'auth-secret',
+				client_id: 'pubky.app',
+				client_public_key: 'client-pubky',
+				capabilities: [{ path: '/pub/pubky.app/session.json', permission: 'write' }],
+				x_success: xCallback.xSuccess,
+			}),
+		);
+
+		const result = await createConfirmAuthPayload({
+			pubky: 'pubky-selected',
+			data: {
+				action: InputAction.Auth,
+				params: {
+					relay: 'wss://relay.example.com',
+					secret: 'auth-secret',
+					kind: 'signin_grant',
+					caps: ['/pub/pubky.app/session.json:write'],
+					xCallback,
+				},
+				rawUrl: 'pubkyauth://signin_grant?secret=auth-secret',
+			},
+		});
+
+		expect(parseDeepLinkMock).toHaveBeenCalledWith('pubkyauth://signin_grant?secret=auth-secret');
+		expect(result.isOk()).toBe(true);
+		if (result.isOk()) {
+			expect(result.value.authDetails).toMatchObject({
+				relay: 'wss://relay.example.com',
+				secret: 'auth-secret',
+				kind: 'signin_grant',
+				capabilities: [{ path: '/pub/pubky.app/session.json', permission: 'write' }],
+				client_id: 'pubky.app',
+				client_public_key: 'client-pubky',
+				x_success: xCallback.xSuccess,
+			});
+			expect(result.value.xCallback).toBe(xCallback);
+		}
+	});
+
+	it('rejects non-auth deeplinks', async () => {
+		parseDeepLinkMock.mockResolvedValueOnce(
+			ok({
+				scheme: 'pubkyring',
+				kind: 'secret_export',
+				url: 'pubkyring://secret_export?secret=secret-value',
+				secret: 'secret-value',
+			}),
+		);
+
+		const result = await createConfirmAuthPayload({
+			pubky: 'pubky-selected',
+			data: {
+				action: InputAction.Auth,
+				params: {
+					relay: 'wss://relay.example.com',
+					secret: 'auth-secret',
+					caps: [],
+				},
+				rawUrl: 'pubkyring://secret_export?secret=secret-value',
+			},
+		});
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error.message).toBe('errors.failedToParseAuth');
+		}
+	});
+
+	it('returns parser errors', async () => {
+		parseDeepLinkMock.mockResolvedValueOnce(err('bad auth url'));
+
+		const result = await createConfirmAuthPayload({
+			pubky: 'pubky-selected',
+			data: {
+				action: InputAction.Auth,
+				params: {
+					relay: 'wss://relay.example.com',
+					secret: 'auth-secret',
+					caps: [],
+				},
+				rawUrl: 'not-auth',
+			},
+		});
+
+		expect(result.isErr()).toBe(true);
+		if (result.isErr()) {
+			expect(result.error.message).toBe('bad auth url');
+		}
+	});
+});

--- a/__tests__/inputParser.test.ts
+++ b/__tests__/inputParser.test.ts
@@ -2,19 +2,11 @@ import { InputAction, parseInput } from '../src/utils/inputParser';
 import { EBackupPreference } from '../src/types/pubky';
 import { ok, err } from '@synonymdev/result';
 import * as Pubky from '@synonymdev/react-native-pubky';
+import type { PubkyDeepLinkDetails } from '@synonymdev/react-native-pubky';
 
-jest.mock('@synonymdev/react-native-pubky', () => {
-	const { err: resultErr } = require('@synonymdev/result');
+jest.mock('@synonymdev/react-native-pubky');
 
-	return {
-		__esModule: true,
-		parseAuthUrl: jest.fn(async () => resultErr('not an auth url')),
-		mnemonicPhraseToKeypair: jest.fn(async () => resultErr('not a mnemonic')),
-		getPublicKeyFromSecretKey: jest.fn(async () => resultErr('not a secret key')),
-	};
-});
-
-const parseAuthUrlMock = Pubky.parseAuthUrl as jest.MockedFunction<typeof Pubky.parseAuthUrl>;
+const parseDeepLinkMock = Pubky.parseDeepLink as jest.MockedFunction<typeof Pubky.parseDeepLink>;
 const mnemonicPhraseToKeypairMock = Pubky.mnemonicPhraseToKeypair as jest.MockedFunction<
 	typeof Pubky.mnemonicPhraseToKeypair
 >;
@@ -22,10 +14,14 @@ const getPublicKeyFromSecretKeyMock = Pubky.getPublicKeyFromSecretKey as jest.Mo
 	typeof Pubky.getPublicKeyFromSecretKey
 >;
 const homeserverPubkey = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
+const mockDeepLink = (details: PubkyDeepLinkDetails): void => {
+	parseDeepLinkMock.mockResolvedValue(ok(details));
+};
 
 describe('parseInput', () => {
 	beforeEach(() => {
-		parseAuthUrlMock.mockResolvedValue(err('not an auth url'));
+		jest.clearAllMocks();
+		parseDeepLinkMock.mockResolvedValue(err('not a deeplink'));
 		mnemonicPhraseToKeypairMock.mockResolvedValue(err('not a mnemonic'));
 		getPublicKeyFromSecretKeyMock.mockResolvedValue(err('not a secret key'));
 	});
@@ -73,6 +69,9 @@ describe('parseInput', () => {
 				},
 			},
 		});
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(
+			'https://example.com/invite/ABCD-1234-WXYZ?x-success=pubky://invite/accepted?token=abc&next=home',
+		);
 	});
 
 	it('parses standalone invite codes', async () => {
@@ -89,6 +88,7 @@ describe('parseInput', () => {
 			source: 'clipboard',
 			rawInput: 'ABCD-1234-WXYZ',
 		});
+		expect(parseDeepLinkMock).toHaveBeenCalledWith('ABCD-1234-WXYZ');
 	});
 
 	it('parses pubkyring invite deeplinks', async () => {
@@ -106,6 +106,7 @@ describe('parseInput', () => {
 			source: 'clipboard',
 			rawInput,
 		});
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(rawInput);
 	});
 
 	it('parses migration deeplinks before stripping protocols', async () => {
@@ -137,9 +138,25 @@ describe('parseInput', () => {
 			'&caps=pubky.app:read,pubky.app:write' +
 			`&x-success=${encodeURIComponent(xSuccess)}` +
 			'&x-source=Bitkit';
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'signup',
+			url: rawInput.replace('pubkyring://', 'pubkyauth://'),
+			homeserver: homeserverPubkey,
+			signup_token: 'ABCD-1234-WXYZ',
+			relay: 'wss://relay.example.com',
+			secret: 'secret-value',
+			capabilities: [
+				{ path: 'pubky.app', permission: 'read' },
+				{ path: 'pubky.app', permission: 'write' },
+			],
+			x_success: xSuccess,
+			x_source: 'Bitkit',
+		});
 
 		const parsed = await parseInput(rawInput, 'deeplink');
 
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(expect.stringContaining('pubkyauth://signup?'));
 		expect(parsed.action).toBe(InputAction.Signup);
 		expect(parsed.data).toEqual({
 			action: InputAction.Signup,
@@ -149,6 +166,7 @@ describe('parseInput', () => {
 				relay: 'wss://relay.example.com',
 				secret: 'secret-value',
 				caps: ['pubky.app:read', 'pubky.app:write'],
+				kind: 'signup',
 				xCallback: {
 					xSuccess,
 					xError: undefined,
@@ -159,11 +177,52 @@ describe('parseInput', () => {
 		});
 	});
 
+	it('preserves signup grant auth intent from the Pubky deeplink parser', async () => {
+		const rawInput =
+			'pubkyauth://signup_grant?' +
+			`hs=${homeserverPubkey}` +
+			`&relay=${encodeURIComponent('wss://relay.example.com')}` +
+			'&secret=secret-value' +
+			'&caps=pubky.app:write';
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'signup_grant',
+			url: rawInput,
+			homeserver: homeserverPubkey,
+			relay: 'wss://relay.example.com',
+			secret: 'secret-value',
+			capabilities: [{ path: 'pubky.app', permission: 'write' }],
+		});
+
+		const parsed = await parseInput(rawInput, 'deeplink');
+
+		expect(parsed.action).toBe(InputAction.Signup);
+		expect(parsed.data).toEqual({
+			action: InputAction.Signup,
+			params: {
+				homeserver: homeserverPubkey,
+				inviteCode: '',
+				relay: 'wss://relay.example.com',
+				secret: 'secret-value',
+				caps: ['pubky.app:write'],
+				kind: 'signup_grant',
+				xCallback: undefined,
+			},
+		});
+	});
+
 	it('parses direct signup deeplinks without auth parameters', async () => {
 		const rawInput =
 			'pubkyauth://direct_signup?' +
 			`hs=${homeserverPubkey}` +
 			'&st=ABCD-1234-WXYZ';
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'direct_signup',
+			url: rawInput,
+			homeserver: homeserverPubkey,
+			signup_token: 'ABCD-1234-WXYZ',
+		});
 
 		const parsed = await parseInput(rawInput, 'scan');
 
@@ -180,6 +239,12 @@ describe('parseInput', () => {
 
 	it('parses direct signup deeplinks without signup tokens', async () => {
 		const rawInput = `pubkyauth://direct_signup?hs=${homeserverPubkey}`;
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'direct_signup',
+			url: rawInput,
+			homeserver: homeserverPubkey,
+		});
 
 		const parsed = await parseInput(rawInput, 'scan');
 
@@ -194,8 +259,15 @@ describe('parseInput', () => {
 		});
 	});
 
-	it('routes legacy signup deeplinks without auth parameters to direct signup', async () => {
+	it('routes signup deeplinks without auth parameters when accepted by Pubky parser', async () => {
 		const rawInput = `pubkyauth://signup?hs=${homeserverPubkey}&st=ABCD-1234-WXYZ`;
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'signup',
+			url: rawInput,
+			homeserver: homeserverPubkey,
+			signup_token: 'ABCD-1234-WXYZ',
+		});
 
 		const parsed = await parseInput(rawInput, 'scan');
 
@@ -210,18 +282,20 @@ describe('parseInput', () => {
 		});
 	});
 
-	it('parses signin deeplinks through the Pubky auth parser', async () => {
-		parseAuthUrlMock.mockResolvedValue(
-			ok({
-				relay: 'wss://relay.example.com',
-				secret: 'auth-secret',
-				capabilities: [
-					{ path: '/pub/pubky.app/profile.json', permission: 'read' },
-					{ path: '/pub/pubky.app/session.json', permission: 'write' },
-				],
-			}),
-		);
+	it('parses signin deeplinks through the Pubky deeplink parser', async () => {
 		const xCancel = 'bitkit://auth/cancel?nonce=abc&reason=user';
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			relay: 'wss://relay.example.com',
+			secret: 'auth-secret',
+			kind: 'signin',
+			url: 'pubkyauth://signin?caps=ignored-by-mock',
+			capabilities: [
+				{ path: '/pub/pubky.app/profile.json', permission: 'read' },
+				{ path: '/pub/pubky.app/session.json', permission: 'write' },
+			],
+			x_cancel: xCancel,
+		});
 		const rawInput =
 			'pubkyring://signin?' +
 			'caps=ignored-by-mock' +
@@ -231,13 +305,16 @@ describe('parseInput', () => {
 
 		const parsed = await parseInput(rawInput, 'deeplink');
 
-		expect(parseAuthUrlMock).toHaveBeenCalledWith(expect.stringContaining('pubkyauth:///?'));
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(expect.stringContaining('pubkyauth://signin?'));
 		expect(parsed.action).toBe(InputAction.Auth);
 		expect(parsed.data).toEqual({
 			action: InputAction.Auth,
 			params: {
 				relay: 'wss://relay.example.com',
 				secret: 'auth-secret',
+				kind: 'signin',
+				homeserver: undefined,
+				signupToken: undefined,
 				caps: ['/pub/pubky.app/profile.json:read', '/pub/pubky.app/session.json:write'],
 				xCallback: {
 					xSuccess: undefined,
@@ -246,7 +323,124 @@ describe('parseInput', () => {
 					xSource: undefined,
 				},
 			},
-			rawUrl: expect.stringContaining('pubkyauth:///?'),
+			rawUrl: expect.stringContaining('pubkyauth://signin?'),
+		});
+	});
+
+	it('preserves grant auth intent from the Pubky deeplink parser', async () => {
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			relay: 'wss://relay.example.com',
+			secret: 'auth-secret',
+			kind: 'signin_grant',
+			url: 'pubkyauth://signin_grant?caps=ignored-by-mock',
+			capabilities: [{ path: '/pub/pubky.app/session.json', permission: 'write' }],
+		});
+
+		const rawInput =
+			'pubkyauth://signin_grant?caps=ignored-by-mock&secret=auth-secret&relay=wss://relay.example.com';
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(rawInput);
+		expect(parsed.action).toBe(InputAction.Auth);
+		expect(parsed.data).toEqual({
+			action: InputAction.Auth,
+			params: {
+				relay: 'wss://relay.example.com',
+				secret: 'auth-secret',
+				kind: 'signin_grant',
+				homeserver: undefined,
+				signupToken: undefined,
+				caps: ['/pub/pubky.app/session.json:write'],
+				xCallback: undefined,
+			},
+			rawUrl: rawInput,
+		});
+	});
+
+	it('parses grant auth deeplinks through the Pubky deeplink parser', async () => {
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'signin_grant',
+			url: 'pubkyauth://signin_grant?caps=ignored-by-mock',
+			relay: 'wss://relay.example.com',
+			secret: 'auth-secret',
+			client_id: 'pubky.app',
+			client_public_key: 'client-pubky',
+			capabilities: [{ path: '/pub/pubky.app/session.json', permission: 'write' }],
+		});
+
+		const rawInput =
+			'pubkyauth://signin_grant?caps=ignored-by-mock&secret=auth-secret&relay=wss://relay.example.com';
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(rawInput);
+		expect(parsed.action).toBe(InputAction.Auth);
+		expect(parsed.data).toEqual({
+			action: InputAction.Auth,
+			params: {
+				relay: 'wss://relay.example.com',
+				secret: 'auth-secret',
+				kind: 'signin_grant',
+				homeserver: undefined,
+				signupToken: undefined,
+				caps: ['/pub/pubky.app/session.json:write'],
+				xCallback: undefined,
+			},
+			rawUrl: rawInput,
+		});
+	});
+
+	it('parses direct signup deeplinks through the Pubky deeplink parser', async () => {
+		mockDeepLink({
+			scheme: 'pubkyauth',
+			kind: 'direct_signup',
+			url: `pubkyauth://direct_signup?hs=${homeserverPubkey}&st=ABCD-1234-WXYZ`,
+			homeserver: homeserverPubkey,
+			signup_token: 'ABCD-1234-WXYZ',
+		});
+
+		const rawInput = `pubkyauth://direct_signup?hs=${homeserverPubkey}&st=ABCD-1234-WXYZ`;
+
+		const parsed = await parseInput(rawInput, 'scan');
+
+		expect(parseDeepLinkMock).toHaveBeenCalledWith(rawInput);
+		expect(parsed.action).toBe(InputAction.DirectSignup);
+		expect(parsed.data).toEqual({
+			action: InputAction.DirectSignup,
+			params: {
+				homeserver: homeserverPubkey,
+				inviteCode: 'ABCD-1234-WXYZ',
+				xCallback: undefined,
+			},
+		});
+	});
+
+	it('parses secret export deeplinks through the Pubky deeplink parser', async () => {
+		mockDeepLink({
+			scheme: 'pubkyring',
+			kind: 'secret_export',
+			url: 'pubkyring://secret_export?secret=secret-value',
+			secret: 'secret-value',
+		});
+
+		const rawInput = 'pubkyring://secret_export?secret=secret-value';
+
+		const parsed = await parseInput(rawInput, 'deeplink');
+
+		expect(parsed).toEqual({
+			action: InputAction.Import,
+			data: {
+				action: InputAction.Import,
+				params: {
+					data: 'secret-value',
+					backupPreference: EBackupPreference.encryptedFile,
+				},
+			},
+			source: 'deeplink',
+			rawInput,
 		});
 	});
 

--- a/__tests__/inputRouter.test.ts
+++ b/__tests__/inputRouter.test.ts
@@ -16,18 +16,13 @@ import { handleSessionAction } from '../src/utils/actions/sessionAction';
 import { showSheet } from '../src/sheets/sheetNavigation';
 import { routeInputWithContext } from '../src/utils/inputHandlerUtils';
 
+jest.mock('@synonymdev/react-native-pubky');
+
 jest.mock('../src/i18n', () => ({
 	__esModule: true,
 	default: {
 		t: (key: string) => key,
 	},
-}));
-
-jest.mock('@synonymdev/react-native-pubky', () => ({
-	__esModule: true,
-	parseAuthUrl: jest.fn(),
-	mnemonicPhraseToKeypair: jest.fn(),
-	getPublicKeyFromSecretKey: jest.fn(),
 }));
 
 jest.mock('@synonymdev/react-native-toast', () => ({

--- a/__tests__/migrateAction.test.ts
+++ b/__tests__/migrateAction.test.ts
@@ -5,16 +5,13 @@ import { hideActiveSheet, showSheet } from '../src/sheets/sheetNavigation';
 import { importPubky } from '../src/utils/pubky';
 import { mnemonicPhraseToKeypair } from '@synonymdev/react-native-pubky';
 
+jest.mock('@synonymdev/react-native-pubky');
+
 jest.mock('../src/i18n', () => ({
 	__esModule: true,
 	default: {
 		t: (key: string) => key,
 	},
-}));
-
-jest.mock('@synonymdev/react-native-pubky', () => ({
-	__esModule: true,
-	mnemonicPhraseToKeypair: jest.fn(),
 }));
 
 jest.mock('@synonymdev/react-native-toast', () => ({

--- a/__tests__/pubkyMigrations.test.ts
+++ b/__tests__/pubkyMigrations.test.ts
@@ -1,19 +1,39 @@
-jest.mock('@synonymdev/react-native-pubky', () => ({
-	__esModule: true,
-	signOut: jest.fn(async () => ({
-		isErr: () => false,
-	})),
-}));
-
 import { signOut } from '@synonymdev/react-native-pubky';
+import { ok as resultOk } from '@synonymdev/result';
 import migrations from '../src/store/migrations';
 import { EBackupPreference } from '../src/types/pubky';
+import { getSessionSecret, resetSessionSecret } from '../src/utils/keychain';
+
+jest.mock('@synonymdev/react-native-pubky');
+
+jest.mock('../src/utils/keychain', () => ({
+	__esModule: true,
+	getSessionSecret: jest.fn(async () => {
+		const { err: resultErr } = require('@synonymdev/result');
+		return resultErr('missing session secret');
+	}),
+	resetSessionSecret: jest.fn(async () => {
+		const { ok } = require('@synonymdev/result');
+		return ok(true);
+	}),
+}));
 
 const signOutMock = signOut as jest.MockedFunction<typeof signOut>;
+const getSessionSecretMock = getSessionSecret as jest.MockedFunction<typeof getSessionSecret>;
+const resetSessionSecretMock = resetSessionSecret as jest.MockedFunction<typeof resetSessionSecret>;
+
+const runMigration = <TState>(version: number, state: TState): TState => {
+	const migration = (migrations as unknown as Record<number, (persistedState: TState) => TState>)[version];
+	return migration(state);
+};
+const flushPromises = async (): Promise<void> => {
+	await new Promise(resolve => setImmediate(resolve));
+};
 
 describe('pubky migrations', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		signOutMock.mockResolvedValue(resultOk(''));
 	});
 
 	it('revokes legacy sessions before dropping their persisted bearer secrets', () => {
@@ -42,11 +62,45 @@ describe('pubky migrations', () => {
 				},
 			},
 		};
-		const migration = (migrations as unknown as Record<number, (persistedState: typeof state) => typeof state>)[7];
-
-		const migratedState = migration(state);
+		const migratedState = runMigration(7, state);
 
 		expect(signOutMock).toHaveBeenCalledWith('pubkyOne:bearer-cookie');
 		expect(migratedState.pubky.pubkys.pubkyOne.sessions).toEqual([]);
+	});
+
+	it('drops stored cookie sessions and clears keychain secrets for grant auth migration', async () => {
+		getSessionSecretMock.mockResolvedValueOnce(resultOk('pubkyOne:stored-cookie'));
+		const state = {
+			pubky: {
+				deepLink: '',
+				processing: {},
+				pubkys: {
+					pubkyOne: {
+						name: 'Alice',
+						homeserver: 'https://homeserver.example',
+						signedUp: true,
+						signupToken: '',
+						image: '',
+						sessions: [
+							{
+								id: 'session-id',
+								capabilities: ['/'],
+								created_at: 123,
+							},
+						],
+						backupPreference: EBackupPreference.encryptedFile,
+						isBackedUp: true,
+					},
+				},
+			},
+		};
+
+		const migratedState = runMigration(8, state);
+		await flushPromises();
+
+		expect(migratedState.pubky.pubkys.pubkyOne.sessions).toEqual([]);
+		expect(getSessionSecretMock).toHaveBeenCalledWith({ pubky: 'pubkyOne', sessionId: 'session-id' });
+		expect(signOutMock).toHaveBeenCalledWith('pubkyOne:stored-cookie');
+		expect(resetSessionSecretMock).toHaveBeenCalledWith({ pubky: 'pubkyOne', sessionId: 'session-id' });
 	});
 });

--- a/__tests__/sessionAction.test.ts
+++ b/__tests__/sessionAction.test.ts
@@ -21,12 +21,7 @@ jest.mock('@synonymdev/react-native-toast', () => ({
 	showToast: jest.fn(),
 }));
 
-jest.mock('@synonymdev/react-native-pubky', () => ({
-	__esModule: true,
-	parseAuthUrl: jest.fn(),
-	mnemonicPhraseToKeypair: jest.fn(),
-	getPublicKeyFromSecretKey: jest.fn(),
-}));
+jest.mock('@synonymdev/react-native-pubky');
 
 jest.mock('../src/sheets/sheetNavigation', () => ({
 	__esModule: true,
@@ -76,7 +71,7 @@ describe('session actions', () => {
 		signInToHomeserverMock.mockResolvedValue(
 			ok({
 				pubky: 'pubky-selected',
-				session_secret: 'pubky-selected:session-cookie',
+				grant_secret: 'pubky-selected:grant-secret',
 				capabilities: ['/', '/pub'],
 			}),
 		);
@@ -132,7 +127,7 @@ describe('session actions', () => {
 		expect(openXSuccessWithParamsMock).not.toHaveBeenCalled();
 	});
 
-	it('returns the session secret only after explicit approval', async () => {
+	it('returns the grant secret only after explicit approval', async () => {
 		const result = await executeSessionAction(sessionData, { dispatch, pubky: 'pubky-selected' });
 
 		expect(result.isOk()).toBe(true);
@@ -142,7 +137,7 @@ describe('session actions', () => {
 		});
 		expect(openXSuccessWithParamsMock).toHaveBeenCalledWith(sessionData.params.xCallback, {
 			pubky: 'pubky-selected',
-			session_secret: 'pubky-selected:session-cookie',
+			grant_secret: 'pubky-selected:grant-secret',
 			capabilities: '/,/pub',
 		});
 	});

--- a/__tests__/signupAction.test.ts
+++ b/__tests__/signupAction.test.ts
@@ -5,24 +5,16 @@ import { hideSheet } from '../src/sheets/sheetNavigation';
 import { savePubky, signUpToHomeserver } from '../src/utils/pubky';
 import { getSignedUpPubkysFromStore } from '../src/utils/store-helpers';
 import { EBackupPreference } from '../src/types/pubky';
+import { generateMnemonicPhraseAndKeypair } from '@synonymdev/react-native-pubky';
+import { ok as resultOk } from '@synonymdev/result';
+
+jest.mock('@synonymdev/react-native-pubky');
 
 jest.mock('../src/i18n', () => ({
 	__esModule: true,
 	default: {
 		t: (key: string) => key,
 	},
-}));
-
-jest.mock('@synonymdev/react-native-pubky', () => ({
-	__esModule: true,
-	generateMnemonicPhraseAndKeypair: jest.fn(async () => {
-		const { ok } = require('@synonymdev/result');
-		return ok({
-			mnemonic: 'one two three four five six seven eight nine ten eleven twelve',
-			secret_key: 'secret-key',
-			public_key: 'pubky-created',
-		});
-	}),
 }));
 
 jest.mock('@synonymdev/react-native-toast', () => ({
@@ -38,7 +30,7 @@ jest.mock('../src/utils/pubky', () => ({
 	}),
 	signUpToHomeserver: jest.fn(async () => {
 		const { ok } = require('@synonymdev/result');
-		return ok({ session_secret: 'session-secret' });
+		return ok({ grant_secret: 'grant-secret' });
 	}),
 }));
 
@@ -92,6 +84,9 @@ const handleAuthActionMock = handleAuthAction as jest.MockedFunction<typeof hand
 const hideSheetMock = hideSheet as jest.MockedFunction<typeof hideSheet>;
 const savePubkyMock = savePubky as jest.MockedFunction<typeof savePubky>;
 const signUpToHomeserverMock = signUpToHomeserver as jest.MockedFunction<typeof signUpToHomeserver>;
+const generateMnemonicPhraseAndKeypairMock = generateMnemonicPhraseAndKeypair as jest.MockedFunction<
+	typeof generateMnemonicPhraseAndKeypair
+>;
 const getSignedUpPubkysFromStoreMock = getSignedUpPubkysFromStore as jest.MockedFunction<
 	typeof getSignedUpPubkysFromStore
 >;
@@ -100,6 +95,14 @@ const homeserverPubkey = '8um71us3fyw6h8wbcxb5ar3rwusy1a6u49956ikzojg3gcwd1dty';
 describe('handleSignupAction', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		generateMnemonicPhraseAndKeypairMock.mockResolvedValue(
+			resultOk({
+				mnemonic: 'one two three four five six seven eight nine ten eleven twelve',
+				secret_key: 'secret-key',
+				public_key: 'pubky-created',
+				uri: 'pubky://pubky-created',
+			}),
+		);
 	});
 
 	it('signs up directly without delivering auth when auth params are absent', async () => {
@@ -181,6 +184,7 @@ describe('handleSignupAction', () => {
 					relay: 'wss://relay.example.com',
 					secret: 'auth-secret',
 					caps: ['pubky.app:read', 'pubky.app:write'],
+					kind: 'signup_grant',
 					xCallback,
 				},
 			},
@@ -195,10 +199,11 @@ describe('handleSignupAction', () => {
 					relay: 'wss://relay.example.com',
 					secret: 'auth-secret',
 					caps: ['pubky.app:read', 'pubky.app:write'],
+					kind: 'signin_grant',
 					xCallback,
 				},
 				rawUrl:
-					'pubkyauth:///?relay=wss%3A%2F%2Frelay.example.com&secret=auth-secret&caps=pubky.app%3Aread%2Cpubky.app%3Awrite',
+					'pubkyauth://signin_grant?relay=wss%3A%2F%2Frelay.example.com&secret=auth-secret&caps=pubky.app%3Aread%2Cpubky.app%3Awrite',
 			},
 			{ dispatch, setAddPubkyScreen, pubky: 'pubky-created', isDeeplink: false },
 		);

--- a/__tests__/useReplacementRelease.test.ts
+++ b/__tests__/useReplacementRelease.test.ts
@@ -6,6 +6,19 @@ import {
 	type ReplacementReleaseStorage,
 } from '../src/hooks/useReplacementRelease';
 
+jest.mock('react-native', () => {
+	return {
+		Platform: {
+			OS: 'android',
+		},
+		NativeModules: {
+			AppInfo: {
+				applicationId: 'to.pubky.ring',
+			},
+		},
+	};
+});
+
 jest.mock('react-native-mmkv', () => ({
 	createMMKV: () => ({ getString: jest.fn(), set: jest.fn() }),
 }));

--- a/__tests__/xCallback.test.ts
+++ b/__tests__/xCallback.test.ts
@@ -49,11 +49,11 @@ describe('xCallback', () => {
 
 		await openXSuccessWithParams(
 			{ xSuccess: 'bitkit://session/return' },
-			{ session_secret: 'pubky:secret-cookie' },
+			{ grant_secret: 'pubky:grant-secret' },
 		);
 
 		expect(warnSpy).toHaveBeenCalledWith('Failed to open x-callback URL');
-		expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('pubky:secret-cookie'));
+		expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('pubky:grant-secret'));
 		warnSpy.mockRestore();
 	});
 });

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1567,7 +1567,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-pubky (0.13.0):
+  - react-native-pubky (0.14.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2907,7 +2907,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 15cca2d1a6bfb6d0d3ff0283bd9b903e57cb028b
   react-native-image-picker: 23540feacc79c63c60857f318fdfa8477c26e70a
   react-native-netinfo: 2f906d5d9a639090ed1c079135d6485a95f749f1
-  react-native-pubky: 3385d7d2bfd974e58dda4736c30df1a96b0121d0
+  react-native-pubky: 493fdd3beeb7ecb16a492f1b01036805478f75d2
   react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
   react-native-skia: b319389e81797af11985805fcfad0714b8670cab
   React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd

--- a/ios/pubkyring/AppInfo.m
+++ b/ios/pubkyring/AppInfo.m
@@ -12,10 +12,12 @@ RCT_EXPORT_MODULE();
   NSBundle *bundle = NSBundle.mainBundle;
   NSString *version = [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: @"";
   NSString *buildNumber = [bundle objectForInfoDictionaryKey:@"CFBundleVersion"] ?: @"";
+  NSString *applicationId = bundle.bundleIdentifier;
 
   return @{
     @"version": version,
-    @"buildNumber": buildNumber
+    @"buildNumber": buildNumber,
+    @"applicationId": applicationId
   };
 }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: '@react-native/jest-preset',
-  setupFiles: ['react-native-gesture-handler/jestSetup'],
+  setupFiles: ['react-native-gesture-handler/jestSetup', './jest.setup.js'],
   watchman: false,
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,26 @@
+/* global jest */
+
+const { NativeModules } = require('react-native');
+
+const nativeResultError = method => ['true', `Mocked native Pubky.${method} was not configured for this test`];
+
+NativeModules.AppInfo = NativeModules.AppInfo || {
+	applicationId: 'to.pubky.ring',
+	buildNumber: '1',
+	version: '1.0.0',
+};
+
+NativeModules.Pubky = NativeModules.Pubky || new Proxy(
+	{
+		addListener: jest.fn(),
+		removeListeners: jest.fn(),
+	},
+	{
+		get(target, prop) {
+			if (prop in target) return target[prop];
+			if (typeof prop !== 'string') return undefined;
+			target[prop] = jest.fn(async () => nativeResultError(prop));
+			return target[prop];
+		},
+	},
+);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "^2.3.1",
     "@shopify/react-native-skia": "^2.6.2",
-    "@synonymdev/react-native-pubky": "0.13.0",
+    "@synonymdev/react-native-pubky": "0.14.0",
     "@synonymdev/react-native-toast": "0.1.0",
     "@synonymdev/result": "^0.0.2",
     "bip39": "^3.1.0",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -45,7 +45,7 @@ const persistConfig: PersistConfig<RootReducerState> = {
 	storage: reduxStorage,
 	whitelist: ['pubky', 'settings'],
 	migrate: createMigrate(migrations),
-	version: 7,
+	version: 8,
 	transforms: [pubkyTransform],
 };
 

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -1,6 +1,9 @@
 import { PersistedState } from 'redux-persist';
 import { signOut } from '@synonymdev/react-native-pubky';
-import { EBackupPreference, PubkySession } from '../../types/pubky';
+import { EBackupPreference } from '../../types/pubky';
+import { getSessionSecret, resetSessionSecret } from '../../utils/keychain';
+
+type PersistedSession = Record<string, unknown>;
 
 const revokeLegacySession = (session: Record<string, unknown>): void => {
 	if (typeof session.session_secret !== 'string' || session.session_secret.length === 0) {
@@ -15,6 +18,34 @@ const revokeLegacySession = (session: Record<string, unknown>): void => {
 		})
 		.catch(error => {
 			console.error('Failed to revoke legacy homeserver session', error);
+		});
+};
+
+const revokeStoredSession = (pubky: string, session: Record<string, unknown>): void => {
+	if (typeof session.id !== 'string' || session.id.length === 0) {
+		return;
+	}
+
+	const sessionId = session.id;
+	getSessionSecret({ pubky, sessionId })
+		.then(result => {
+			if (result.isErr()) {
+				return;
+			}
+
+			return signOut(result.value).then(signOutResult => {
+				if (signOutResult.isErr()) {
+					console.error('Failed to revoke stored homeserver session', signOutResult.error.message);
+				}
+			});
+		})
+		.catch(error => {
+			console.error('Failed to revoke stored homeserver session', error);
+		})
+		.finally(() => {
+			resetSessionSecret({ pubky, sessionId }).catch(error => {
+				console.error('Failed to reset stored homeserver session', error);
+			});
 		});
 };
 
@@ -101,7 +132,7 @@ const migrations = {
 			if (pubky.sessions && pubky.sessions.length > 0) {
 				updatedPubkys[pubkyKey] = {
 					...pubky,
-					sessions: pubky.sessions.map((session: PubkySession) => ({
+					sessions: pubky.sessions.map((session: PersistedSession) => ({
 						...session,
 						session_secret: '',
 					})),
@@ -144,6 +175,31 @@ const migrations = {
 						capabilities: session.capabilities,
 						created_at: session.created_at,
 					})),
+			};
+		});
+
+		return {
+			...state,
+			pubky: {
+				...state.pubky,
+				pubkys: updatedPubkys,
+			},
+		};
+	},
+	// @ts-ignore
+	8: (state): PersistedState => {
+		const updatedPubkys = { ...state.pubky.pubkys };
+
+		// Grant auth replaces legacy Cookie auth sessions. Keep identities, but
+		// drop existing sessions so apps request fresh grant sessions.
+		Object.keys(updatedPubkys).forEach(pubkyKey => {
+			const pubky = updatedPubkys[pubkyKey];
+			(pubky.sessions ?? []).forEach((session: Record<string, unknown>) => {
+				revokeStoredSession(pubkyKey, session);
+			});
+			updatedPubkys[pubkyKey] = {
+				...pubky,
+				sessions: [],
 			};
 		});
 

--- a/src/utils/actions/authAction.ts
+++ b/src/utils/actions/authAction.ts
@@ -6,7 +6,8 @@
  */
 
 import { Result, ok, err } from '@synonymdev/result';
-import { parseAuthUrl } from '@synonymdev/react-native-pubky';
+import { parseDeepLink } from '@synonymdev/react-native-pubky';
+import type { PubkyAuthDetails, PubkyDeepLinkDetails } from '@synonymdev/react-native-pubky';
 import { showToast } from '@synonymdev/react-native-toast';
 import { showSheet } from '../../sheets/sheetNavigation.tsx';
 import { InputAction, AuthParams, XCallbackParams } from '../inputParser';
@@ -24,6 +25,14 @@ export type AuthActionData = {
 	rawUrl: string;
 };
 
+const isAuthKind = (kind: PubkyDeepLinkDetails['kind']): kind is NonNullable<AuthParams['kind']> => {
+	return kind === 'signin' || kind === 'signup' || kind === 'signin_grant' || kind === 'signup_grant';
+};
+
+const isAuthDetails = (details: PubkyDeepLinkDetails): details is PubkyDeepLinkDetails & PubkyAuthDetails => {
+	return isAuthKind(details.kind) && Boolean(details.relay && details.secret);
+};
+
 export const createConfirmAuthPayload = async ({
 	data,
 	pubky,
@@ -31,17 +40,25 @@ export const createConfirmAuthPayload = async ({
 	data: AuthActionData;
 	pubky: string;
 }): Promise<Result<ConfirmAuthPayload>> => {
-	const authResult = await parseAuthUrl(data.rawUrl);
+	const authResult = await parseDeepLink(data.rawUrl);
 
 	if (authResult.isErr()) {
 		const description = authResult.error?.message ?? i18n.t('errors.failedToParseAuth');
 		return err(description);
 	}
 
+	const authDetails = authResult.value;
+	if (!isAuthDetails(authDetails)) {
+		return err(i18n.t('errors.failedToParseAuth'));
+	}
+
 	return ok({
 		pubky,
 		authUrl: data.rawUrl,
-		authDetails: authResult.value,
+		authDetails: {
+			...authDetails,
+			capabilities: authDetails.capabilities ?? [],
+		},
 		xCallback: data.params.xCallback,
 	});
 };

--- a/src/utils/actions/sessionAction.ts
+++ b/src/utils/actions/sessionAction.ts
@@ -9,7 +9,7 @@
  *    (or legacy: pubkyring://session?callback=bitkit://session-data)
  * 2. Ring prompts user to select a pubky when needed
  * 3. Ring prompts the user to approve handing a homeserver session to the callback app
- * 4. Ring opens x-success URL with session data: bitkit://session-data?pubky=...&session_secret=...
+ * 4. Ring opens x-success URL with session data: bitkit://session-data?pubky=...&grant_secret=...
  */
 
 import { Result, ok, err } from '@synonymdev/result';
@@ -108,7 +108,7 @@ export const executeSessionAction = async (
 		// Open x-success URL with session data appended as query params
 		await openXSuccessWithParams(xCallback, {
 			pubky: sessionInfo.pubky,
-			session_secret: sessionInfo.session_secret,
+			grant_secret: sessionInfo.grant_secret,
 			capabilities: sessionInfo.capabilities.join(','),
 		});
 

--- a/src/utils/actions/signupAction.ts
+++ b/src/utils/actions/signupAction.ts
@@ -62,11 +62,12 @@ const showErrorState = (
 
 const createSignupAuthData = (params: SignupParams): AuthActionData => {
 	const { relay, secret, xCallback } = params;
+	const kind = params.kind === 'signup_grant' ? 'signin_grant' : 'signin';
 
 	return {
 		action: InputAction.Auth,
-		params: { relay, secret, caps: params.caps, xCallback },
-		rawUrl: `pubkyauth:///?relay=${encodeURIComponent(relay)}&secret=${encodeURIComponent(
+		params: { relay, secret, caps: params.caps, kind, xCallback },
+		rawUrl: `pubkyauth://${kind}?relay=${encodeURIComponent(relay)}&secret=${encodeURIComponent(
 			secret,
 		)}&caps=${encodeURIComponent(params.caps.join(','))}`,
 	};

--- a/src/utils/appInfo.ts
+++ b/src/utils/appInfo.ts
@@ -3,11 +3,11 @@ import { NativeModules } from 'react-native';
 type AppInfoConstants = {
 	version?: string;
 	buildNumber?: string;
-	applicationId?: string;
+	applicationId: string;
 };
 
-const appInfo = NativeModules.AppInfo as AppInfoConstants | undefined;
+const appInfo = NativeModules.AppInfo as AppInfoConstants;
 
 export const appVersion = appInfo?.version ?? '';
 export const appBuildNumber = appInfo?.buildNumber ?? '';
-export const appApplicationId = appInfo?.applicationId ?? '';
+export const appApplicationId = appInfo.applicationId;

--- a/src/utils/inputParser.ts
+++ b/src/utils/inputParser.ts
@@ -10,7 +10,7 @@
  * that can be routed to the appropriate action handler.
  */
 
-import { parseAuthUrl } from '@synonymdev/react-native-pubky';
+import { parseDeepLink, PubkyDeepLinkDetails } from '@synonymdev/react-native-pubky';
 import { mnemonicPhraseToKeypair, getPublicKeyFromSecretKey } from '@synonymdev/react-native-pubky';
 import { EBackupPreference } from '../types/pubky';
 
@@ -37,6 +37,7 @@ export interface SignupParams {
 	relay: string;
 	secret: string;
 	caps: string[];
+	kind?: 'signup' | 'signup_grant';
 	xCallback?: XCallbackParams;
 }
 
@@ -64,7 +65,7 @@ export interface AuthParams {
 	// are 'signin'. Well-formed signup links (with an hs param) are routed to
 	// InputAction.Signup instead, so 'signup' here means a malformed signup
 	// link that was missing its homeserver.
-	kind?: 'signin' | 'signup';
+	kind?: 'signin' | 'signup' | 'signin_grant' | 'signup_grant';
 	homeserver?: string;
 	signupToken?: string;
 	xCallback?: XCallbackParams;
@@ -236,63 +237,6 @@ export const extractXCallbackParams = (encodedQueryString: string): XCallbackPar
 };
 
 /**
- * Parses signup deeplink parameters
- * Format: signup?hs={homeserver}&relay={relay_url}&secret={secret}&caps={capabilities}[&st={signup_token}]
- *
- * `queryString` is the (possibly multi-pass-decoded) query for plain fields;
- * `encodedQueryString` is the original encoded query used for x-callback
- * extraction so inner callback URLs are preserved verbatim.
- */
-const parseSignupParams = (queryString: string, encodedQueryString: string): SignupParams | null => {
-	try {
-		const params = new URLSearchParams(queryString);
-		const relay = params.get('relay');
-		const secret = params.get('secret');
-
-		if (!relay || !secret) {
-			return null;
-		}
-
-		return {
-			homeserver: decodeURIComponent(params.get('hs') || ''),
-			inviteCode: params.get('st') || '',
-			relay: decodeURIComponent(relay),
-			secret,
-			caps: (params.get('caps') || '').split(',').filter(Boolean),
-			xCallback: extractXCallbackParams(encodedQueryString),
-		};
-	} catch {
-		return null;
-	}
-};
-
-const hasSignupAuthParams = (queryString: string): boolean => {
-	const params = new URLSearchParams(queryString);
-	return Boolean(params.get('relay') && params.get('secret'));
-};
-
-/**
- * Parses direct signup deeplink parameters
- * Format: direct_signup?hs={homeserver_pubkey}[&st={signup_token}]
- */
-const parseDirectSignupParams = (
-	queryString: string,
-	encodedQueryString: string,
-): DirectSignupParams | null => {
-	try {
-		const params = new URLSearchParams(queryString);
-
-		return {
-			homeserver: decodeURIComponent(params.get('hs') || ''),
-			inviteCode: params.get('st') || '',
-			xCallback: extractXCallbackParams(encodedQueryString),
-		};
-	} catch {
-		return null;
-	}
-};
-
-/**
  * Parses session deeplink parameters
  * Format: session?x-success={url}&x-error={url}&x-cancel={url}&x-source={name}
  * Legacy: session?callback={callback_url}
@@ -307,6 +251,162 @@ const parseSessionParams = (encodedQueryString: string): SessionParams | null =>
 	} catch {
 		return null;
 	}
+};
+
+const xCallbackFromDeepLink = (details: PubkyDeepLinkDetails): XCallbackParams | undefined => {
+	const parsed = {
+		xSuccess: details.x_success,
+		xError: details.x_error,
+		xCancel: details.x_cancel,
+		xSource: details.x_source,
+	};
+
+	if (parsed.xSuccess || parsed.xError || parsed.xCancel || parsed.xSource) {
+		return parsed;
+	}
+
+	return undefined;
+};
+
+const capsFromDeepLink = (details: PubkyDeepLinkDetails): string[] => {
+	return details.capabilities?.map(capability => `${capability.path}:${capability.permission}`) ?? [];
+};
+
+const normalizePubkyDeepLinkInput = (input: string): string => {
+	let normalized = input;
+
+	if (normalized.startsWith('pubkyring://pubkyauth://')) {
+		normalized = normalized.replace('pubkyring://', '');
+	}
+
+	if (normalized.startsWith('pubkyauth///')) {
+		normalized = normalized.replace('pubkyauth///', 'pubkyauth:///');
+	}
+
+	if (normalized.startsWith('pubkyring://')) {
+		const path = normalized.replace('pubkyring://', '');
+		if (
+			path.startsWith('signin?') ||
+			path.startsWith('signin/?') ||
+			path.startsWith('signup?') ||
+			path.startsWith('signup/?') ||
+			path.startsWith('direct_signup?') ||
+			path.startsWith('direct_signup/?')
+		) {
+			normalized = `pubkyauth://${path}`;
+		}
+	}
+
+	for (const route of ['signin', 'signup', 'direct_signup', 'signin_grant', 'signup_grant']) {
+		normalized = normalized.replace(`pubkyauth://${route}/?`, `pubkyauth://${route}?`);
+	}
+
+	return normalized;
+};
+
+const parsePubkyDeepLink = async (
+	input: string,
+	rawInput: string,
+	source: InputSource,
+): Promise<ParsedInput | null> => {
+	const normalizedInput = normalizePubkyDeepLinkInput(input);
+	const deepLinkResult = await parseDeepLink(normalizedInput);
+	if (deepLinkResult.isErr()) {
+		return null;
+	}
+
+	const details = deepLinkResult.value;
+	const xCallback = xCallbackFromDeepLink(details);
+
+	if (details.kind === 'direct_signup' && details.homeserver) {
+		return {
+			action: InputAction.DirectSignup,
+			data: {
+				action: InputAction.DirectSignup,
+				params: {
+					homeserver: details.homeserver,
+					inviteCode: details.signup_token ?? '',
+					xCallback,
+				},
+			},
+			source,
+			rawInput,
+		};
+	}
+
+	if ((details.kind === 'signup' || details.kind === 'signup_grant') && details.homeserver) {
+		if (details.relay && details.secret) {
+			return {
+				action: InputAction.Signup,
+				data: {
+					action: InputAction.Signup,
+					params: {
+						homeserver: details.homeserver,
+						inviteCode: details.signup_token ?? '',
+						relay: details.relay,
+						secret: details.secret,
+						caps: capsFromDeepLink(details),
+						kind: details.kind,
+						xCallback,
+					},
+				},
+				source,
+				rawInput,
+			};
+		}
+
+		return {
+			action: InputAction.DirectSignup,
+			data: {
+				action: InputAction.DirectSignup,
+				params: {
+					homeserver: details.homeserver,
+					inviteCode: details.signup_token ?? '',
+					xCallback,
+				},
+			},
+			source,
+			rawInput,
+		};
+	}
+
+	if ((details.kind === 'signin' || details.kind === 'signin_grant') && details.relay && details.secret) {
+		return {
+			action: InputAction.Auth,
+			data: {
+				action: InputAction.Auth,
+				params: {
+					relay: details.relay,
+					secret: details.secret,
+					caps: capsFromDeepLink(details),
+					kind: details.kind,
+					homeserver: details.homeserver,
+					signupToken: details.signup_token,
+					xCallback,
+				},
+				rawUrl: normalizedInput,
+			},
+			source,
+			rawInput,
+		};
+	}
+
+	if (details.kind === 'secret_export' && details.secret) {
+		return {
+			action: InputAction.Import,
+			data: {
+				action: InputAction.Import,
+				params: {
+					data: details.secret,
+					backupPreference: EBackupPreference.encryptedFile,
+				},
+			},
+			source,
+			rawInput,
+		};
+	}
+
+	return null;
 };
 
 /**
@@ -381,16 +481,14 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		}
 	}
 
-	// Remove pubkyring:// wrapper protocol if present
-	// This handles cases like pubkyring://pubkyauth:///?...
-	if (processedInput.startsWith('pubkyring://')) {
-		processedInput = processedInput.replace('pubkyring://', '');
+	const deepLinkParsed = await parsePubkyDeepLink(processedInput, rawInput, source);
+	if (deepLinkParsed) {
+		return deepLinkParsed;
 	}
 
-	// Fix malformed pubkyauth URL (pubkyauth/// -> pubkyauth:///)
-	// Some sources may omit the colon
-	if (processedInput.startsWith('pubkyauth///')) {
-		processedInput = processedInput.replace('pubkyauth///', 'pubkyauth:///');
+	// Remove pubkyring:// wrapper protocol for Ring-owned routes.
+	if (processedInput.startsWith('pubkyring://')) {
+		processedInput = processedInput.replace('pubkyring://', '');
 	}
 
 	// Remove protocol prefixes for further analysis
@@ -400,60 +498,10 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 	}
 
 	// Normalize: remove trailing slash before query string for known routes
-	if (urlWithoutProtocol.startsWith('signup/?'))
-		urlWithoutProtocol = urlWithoutProtocol.replace('signup/?', 'signup?');
-	if (urlWithoutProtocol.startsWith('direct_signup/?'))
-		urlWithoutProtocol = urlWithoutProtocol.replace('direct_signup/?', 'direct_signup?');
 	if (urlWithoutProtocol.startsWith('session/?'))
 		urlWithoutProtocol = urlWithoutProtocol.replace('session/?', 'session?');
-	if (urlWithoutProtocol.startsWith('signin/?'))
-		urlWithoutProtocol = urlWithoutProtocol.replace('signin/?', 'signin?');
 
-	// 1. Check for direct signup deeplink
-	// Format: pubkyauth://direct_signup?...
-	// The signup token (st) is optional per the pubky 0.9.1 deep link spec —
-	// homeservers without invite requirements omit it.
-	if (urlWithoutProtocol.startsWith('direct_signup?')) {
-		const queryString = urlWithoutProtocol.substring('direct_signup?'.length);
-		const directSignupParams = parseDirectSignupParams(queryString, rawEncodedQuery);
-		if (directSignupParams?.homeserver) {
-			return {
-				action: InputAction.DirectSignup,
-				data: { action: InputAction.DirectSignup, params: directSignupParams },
-				source,
-				rawInput,
-			};
-		}
-	}
-
-	// 2. Check for signup deeplink
-	// Format: pubkyring://signup?... or pubkyauth://signup?...
-	if (urlWithoutProtocol.startsWith('signup?')) {
-		const queryString = urlWithoutProtocol.substring('signup?'.length);
-		if (hasSignupAuthParams(queryString)) {
-			const signupParams = parseSignupParams(queryString, rawEncodedQuery);
-			if (signupParams?.homeserver) {
-				return {
-					action: InputAction.Signup,
-					data: { action: InputAction.Signup, params: signupParams },
-					source,
-					rawInput,
-				};
-			}
-		}
-
-		const directSignupParams = parseDirectSignupParams(queryString, rawEncodedQuery);
-		if (directSignupParams?.homeserver) {
-			return {
-				action: InputAction.DirectSignup,
-				data: { action: InputAction.DirectSignup, params: directSignupParams },
-				source,
-				rawInput,
-			};
-		}
-	}
-
-	// 3. Check for session deeplink
+	// 1. Check for session deeplink
 	// Format: pubkyring://session?x-success={url} or pubkyring://session?callback={url}
 	if (urlWithoutProtocol.startsWith('session?')) {
 		const sessionParams = parseSessionParams(rawEncodedQuery);
@@ -467,45 +515,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		}
 	}
 
-	// 4. Check for signin deeplink (alternative auth format)
-	// Format: pubkyring://signin?caps=...&secret=...&relay=...
-	// Convert to pubkyauth:/// format for parsing
-	if (urlWithoutProtocol.startsWith('signin?')) {
-		const queryString = urlWithoutProtocol.substring(7); // Remove "signin?"
-		processedInput = `pubkyauth:///?${queryString}`;
-	}
-
-	// 5. Check for auth URL
-	// Format: pubkyauth:///...
-	const authResult = await parseAuthUrl(processedInput);
-	if (authResult.isOk()) {
-		// Extract optional x-callback-url parameters from the original
-		// (still-encoded) query so inner callback URLs round-trip verbatim.
-		const xCallback = extractXCallbackParams(rawEncodedQuery);
-
-		const details = authResult.value;
-
-		return {
-			action: InputAction.Auth,
-			data: {
-				action: InputAction.Auth,
-				params: {
-					relay: details.relay,
-					secret: details.secret,
-					caps: details.capabilities.map(c => `${c.path}:${c.permission}`),
-					kind: details.kind,
-					homeserver: details.homeserver,
-					signupToken: details.signup_token,
-					xCallback,
-				},
-				rawUrl: processedInput,
-			},
-			source,
-			rawInput,
-		};
-	}
-
-	// 6. Check for invite code in URL
+	// 2. Check for invite code in URL
 	const inviteCode = parseInviteCodeFromUrl(processedInput);
 	if (inviteCode) {
 		// Extract x-callback params from the original encoded query so inner
@@ -519,7 +529,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 7. Check if it's a standalone invite code (XXXX-XXXX-XXXX format)
+	// 3. Check if it's a standalone invite code (XXXX-XXXX-XXXX format)
 	if (isValidInviteCode(urlWithoutProtocol)) {
 		return {
 			action: InputAction.Invite,
@@ -529,7 +539,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 8. Check for import data (recovery phrase or secret key)
+	// 4. Check for import data (recovery phrase or secret key)
 	const formatted = formatImportData(processedInput);
 	const importValidation = await validateImportData(formatted);
 	if (importValidation.isValid) {
@@ -547,7 +557,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		};
 	}
 
-	// 9. Quick check for recovery phrase pattern (12 words) even if validation failed
+	// 5. Quick check for recovery phrase pattern (12 words) even if validation failed
 	// This handles cases where the mnemonic might be valid but validation takes time
 	const words = formatted.trim().split(/\s+/);
 	if (words.length === 12) {
@@ -569,7 +579,7 @@ export const parseInput = async (rawInput: string, source: InputSource): Promise
 		}
 	}
 
-	// 10. Default to unknown
+	// 6. Default to unknown
 	return {
 		action: InputAction.Unknown,
 		data: { action: InputAction.Unknown, params: { rawData: processedInput } },

--- a/src/utils/pubky.ts
+++ b/src/utils/pubky.ts
@@ -3,13 +3,13 @@ import {
 	signIn,
 	signOut,
 	getPublicKeyFromSecretKey,
-	SessionInfo,
 	getSignupToken as _getSignupToken,
 	republishHomeserver as _republishHomeserver,
 	getHomeserver,
 	get,
 	generateMnemonicPhraseAndKeypair,
 	mnemonicPhraseToKeypair,
+	type SessionInfo,
 } from '@synonymdev/react-native-pubky';
 import {
 	setKeychainValue,
@@ -49,13 +49,14 @@ import {
 	STAGING_APP_HOST,
 	STAGING_HOMESERVER,
 } from './constants.ts';
+import { appApplicationId } from './appInfo.ts';
 import i18n from '../i18n';
 
-// Stable UUID v5 namespace for deriving local session ids from homeserver session secrets.
+// Stable UUID v5 namespace for deriving local session ids from homeserver session tokens.
 const SESSION_ID_NAMESPACE = '4dd6b3f6-1ef1-4e8a-9a7b-4bbdb8b69785';
 
-const revokeUnsavedHomeserverSession = async (sessionSecret: string): Promise<void> => {
-	const signOutRes = await signOut(sessionSecret);
+const revokeUnsavedHomeserverSession = async (sessionToken: string): Promise<void> => {
+	const signOutRes = await signOut(sessionToken);
 	if (signOutRes.isErr()) {
 		console.error('Failed to revoke unsaved homeserver session', signOutRes.error.message);
 	}
@@ -71,18 +72,18 @@ const saveHomeserverSession = async ({
 	dispatch: Dispatch;
 }): Promise<Result<PubkySession>> => {
 	const session: PubkySession = {
-		id: uuid(sessionInfo.session_secret, SESSION_ID_NAMESPACE),
+		id: uuid(sessionInfo.grant_secret, SESSION_ID_NAMESPACE),
 		capabilities: sessionInfo.capabilities,
 		created_at: Date.now(),
 	};
 	const secretRes = await setSessionSecret({
 		pubky,
 		sessionId: session.id,
-		sessionSecret: sessionInfo.session_secret,
+		sessionSecret: sessionInfo.grant_secret,
 	});
 
 	if (secretRes.isErr()) {
-		await revokeUnsavedHomeserverSession(sessionInfo.session_secret);
+		await revokeUnsavedHomeserverSession(sessionInfo.grant_secret);
 		return err(secretRes.error);
 	}
 
@@ -555,12 +556,11 @@ export const signUpToHomeserver = async ({
 		}
 		secretKey = secretKeyRes.value.secretKey;
 	}
-	// Pass undefined rather than '' so the FFI receives no signup token
-	// (None) instead of an empty-string token.
-	const signUpRes = await signUp(secretKey, homeserver, signupToken || undefined);
+	const signUpRes = await signUp(secretKey, homeserver, signupToken, appApplicationId);
 	if (signUpRes.isErr()) {
 		return err(getErrorMessage(signUpRes.error, i18n.t('errors.signupFailed')));
 	}
+	const sessionInfo = signUpRes.value;
 	republishHomeserver({
 		pubky,
 		secretKey,
@@ -568,12 +568,12 @@ export const signUpToHomeserver = async ({
 		dispatch,
 	});
 	dispatch(setHomeserver({ pubky, homeserver }));
-	const saveSessionRes = await saveHomeserverSession({ pubky, sessionInfo: signUpRes.value, dispatch });
+	const saveSessionRes = await saveHomeserverSession({ pubky, sessionInfo, dispatch });
 	if (saveSessionRes.isErr()) {
 		return err(getErrorMessage(saveSessionRes.error, i18n.t('keychain.failedToSetValue')));
 	}
 	dispatch(setSignedUp({ pubky, signedUp: true }));
-	return ok(signUpRes.value);
+	return ok(sessionInfo);
 };
 
 export const signInToHomeserver = async ({
@@ -602,7 +602,7 @@ export const signInToHomeserver = async ({
 		secretKey = secretKeyRes.value.secretKey;
 	}
 	let response: SessionInfo;
-	const signInRes = await signIn(secretKey);
+	const signInRes = await signIn(secretKey, appApplicationId);
 	if (signInRes.isErr()) {
 		const republishRes = await republishHomeserver({
 			pubky,
@@ -615,7 +615,7 @@ export const signInToHomeserver = async ({
 			return err(getErrorMessage(signInRes.error, i18n.t('errors.signInFailed')));
 		}
 		// Attempt to signin now
-		const signInResTwo = await signIn(secretKey);
+		const signInResTwo = await signIn(secretKey, appApplicationId);
 		if (signInResTwo.isErr()) {
 			return err(getErrorMessage(signInResTwo.error, i18n.t('errors.signInFailed')));
 		}

--- a/src/utils/xCallback.ts
+++ b/src/utils/xCallback.ts
@@ -68,7 +68,7 @@ export const openXError = async (
 
 /**
  * Opens the x-success URL with additional data appended as query params.
- * Used by flows that need to pass data back (e.g., session returns session_secret).
+ * Used by flows that need to pass data back (e.g., session returns grant_secret).
  */
 export const openXSuccessWithParams = async (
 	xCallback: XCallbackParams | undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,10 +2203,10 @@
   resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
   integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
-"@synonymdev/react-native-pubky@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-pubky/-/react-native-pubky-0.13.0.tgz#728f190c52b446d1bc38fd168e39fce8a527630b"
-  integrity sha512-SQt99CdHqCk1rP1kXSQw5KmNXfP/ZJRCcEJreCMrK7mAMNQRx3qip65vBmVN8207Hr1m6MDWaUFmiwLd/tVwJg==
+"@synonymdev/react-native-pubky@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-pubky/-/react-native-pubky-0.14.0.tgz#0b88344cd199f9f66c51718a1d83a7924b2bcfa8"
+  integrity sha512-JN94I70L3pFzt06X54r0isQAViKKWFKnkieDN44I6ji2isKEfpwElx45P1BwnFm6OegTXUbQT9VI6s+nwbUu6A==
   dependencies:
     "@synonymdev/result" "^0.0.2"
 


### PR DESCRIPTION
## Summary

- Updates Pubky Ring to consume the Pubky 0.10 Grant-auth bindings from `@synonymdev/react-native-pubky@0.14.0`
- Uses Grant auth by default for homeserver signup/signin and session requests
- Passes the native app application id as the Grant auth `clientId` instead of hardcoding a Ring-specific string
- Adds Redux persist migration v8 to drop old cookie sessions and clear/revoke stored session tokens so users re-auth cleanly
- Replaces duplicated Pubky auth deeplink parsing with `parseDeepLink` from `react-native-pubky`
- Preserves signup deeplink behavior by using `hs`/`st` for signup, then continuing auth as `signin` / `signin_grant`
- Returns `grant_secret` for approved external session requests
- Centralizes Pubky Jest mocks and adds coverage for grant deeplinks, auth confirmation parsing, signup auth handoff, session return, and migration cleanup

## Dependency chain

- Depends on pubky-core-ffi PR: https://github.com/pubky/pubky-core-ffi/pull/27
- Depends on react-native-pubky PR: https://github.com/pubky/react-native-pubky/pull/39
- The current dependency is using the locally built `@synonymdev/react-native-pubky@0.14.0` package for verification. Before merge, switch this to the published npm version or another reviewer-fetchable source.

## Verification

- `yarn test --runInBand`
- `yarn typecheck`
- `yarn lint` exits 0 with existing warnings only
- `git diff --check`
- iOS e2e passes locally