### PR TITLE
fix: guard form-sheet detent against out-of-range values (Android 3-button nav)

### DIFF
--- a/__tests__/sheetLayout.test.ts
+++ b/__tests__/sheetLayout.test.ts
@@ -1,0 +1,53 @@
+import { Platform } from 'react-native';
+
+// HEADER_HEIGHT lives in AppHeader.tsx, which pulls in the full header component
+// tree (icons, styled-components, ...). Mock it down to just the constant so this
+// test stays focused on the detent math.
+jest.mock('../src/components/AppHeader.tsx', () => ({ HEADER_HEIGHT: 56 }));
+
+// getSheetDetent branches on isSmallScreen(); force the "regular" (non-small)
+// screen path so we exercise the ratio calculation.
+jest.mock('../src/utils/helpers.ts', () => ({ isSmallScreen: () => false }));
+
+import { getSheetDetent } from '../src/sheets/sheetLayout.ts';
+
+/**
+ * react-native-screens requires a single formSheet detent to satisfy
+ * `detent in 0.0..1.0` (see SheetDetents.kt). A value > 1.0 throws
+ * IllegalArgumentException natively and the sheet fails to present.
+ *
+ * Regression for https://github.com/pubky/pubky-ring/issues/359
+ * "Add pubky button is broken" — the sheet does not display on Android
+ * devices with a tall navigation bar (e.g. Mi Note 11 / MIUI 3-button nav).
+ */
+describe('getSheetDetent (Android)', () => {
+	const originalOS = Platform.OS;
+
+	beforeAll(() => {
+		Platform.OS = 'android';
+	});
+
+	afterAll(() => {
+		Platform.OS = originalOS;
+	});
+
+	it('stays within react-native-screens allowed range (0, 1] for a tall bottom-inset device', () => {
+		// Realistic Mi Note 11 / MIUI 3-button-nav metrics (in dp).
+		const windowHeight = 851;
+		const topInset = 28;
+		const bottomInset = 56;
+
+		const detent = getSheetDetent(windowHeight, topInset, bottomInset);
+
+		expect(detent).toBeGreaterThan(0);
+		// This currently FAILS: the detent is ~1.006, which react-native-screens
+		// rejects, so the Add-pubky sheet never appears.
+		expect(detent).toBeLessThanOrEqual(1);
+	});
+
+	it('stays within range for a small gesture-nav inset (regression guard)', () => {
+		const detent = getSheetDetent(851, 28, 24);
+		expect(detent).toBeGreaterThan(0);
+		expect(detent).toBeLessThanOrEqual(1);
+	});
+});

--- a/src/sheets/sheetLayout.ts
+++ b/src/sheets/sheetLayout.ts
@@ -31,5 +31,7 @@ export const getSheetDetent = (windowHeight: number, topInset: number, bottomIns
 		sheetHeight += bottomInset + ANDROID_DETENT_OVERFLOW_PADDING;
 	}
 
-	return sheetHeight / availableHeight;
+	// react-native-screens requires a single detent in (0, 1]; a taller nav bar (e.g. MIUI
+	// 3-button nav) can otherwise push this above 1.0 and the sheet fails to present.
+	return Math.min(1, sheetHeight / availableHeight);
 };


### PR DESCRIPTION
## What

Hardening: clamp the native-stack `formSheet` detent produced by `getSheetDetent()` (`src/sheets/sheetLayout.ts`) to the range react-native-screens requires — `(0, 1]`.

On Android the detent formula adds the bottom inset back in:

```
detent = (availableHeight - HEADER_HEIGHT(56) + bottomInset + 5) / availableHeight
```

so it exceeds `1.0` when `bottomInset > 51dp` (e.g. a 3-button navigation bar). react-native-screens rejects any single detent outside `0.0..1.0` (`SheetDetents.kt`: `require(it in 0.0..1.0 ...)`), which throws during sheet setup on affected devices.

```ts
return Math.min(1, sheetHeight / availableHeight);
```

Added `__tests__/sheetLayout.test.ts` (computes `1.006` for a tall-nav-bar device pre-fix; passes after).

## Scope / caveat

⚠️ This is a **defensive range guard**, not a confirmed fix for #359. On-device testing on the reported hardware (Redmi/Mi Note 11, Android 13/MIUI, gesture nav) showed the real detent there is `0.9378` (insets report as 0), so the >1.0 path is not what breaks that device. The Add-pubky sheet there mounts but the native `formSheet` isn't drawn until a window relayout (lock/unlock) — a separate react-native-screens native-presentation issue being investigated on its own branch. Keeping this PR as standalone hardening for 3-button-nav devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)