### PR TITLE
fix(android): present sheets as in-window modal so they render

### DIFF
--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -1,5 +1,14 @@
 import React, { memo, ReactElement, ReactNode } from 'react';
-import { ScrollView, StyleProp, StyleSheet, useWindowDimensions, View, ViewStyle } from 'react-native';
+import {
+	Platform,
+	Pressable,
+	ScrollView,
+	StyleProp,
+	StyleSheet,
+	useWindowDimensions,
+	View,
+	ViewStyle,
+} from 'react-native';
 import { useIsFocused, useNavigation, useNavigationState } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import SafeAreaInset from './SafeAreaInset.tsx';
@@ -7,8 +16,10 @@ import { LinearGradient, RadialGradient } from './LinearGradient.tsx';
 import { TextLgSb } from '../theme/typography.ts';
 import HeaderNavButton from './HeaderNavButton.tsx';
 import { ArrowLeft } from '../icons/index.ts';
+import { HEADER_HEIGHT } from './AppHeader.tsx';
 import type { SheetId } from '../sheets/types.ts';
 import { getSheetContentHeight } from '../sheets/sheetLayout.ts';
+import { hideActiveSheet } from '../sheets/sheetNavigation.tsx';
 import { ThemedView } from '../theme/components.ts';
 
 export type GradientType = 'none' | 'brand' | 'danger';
@@ -41,8 +52,21 @@ const gradientColors: Record<Exclude<GradientType, 'none'>, string[]> = {
 export const SheetFrame = ({ children }: SheetFrameProps): ReactElement => {
 	const { height: windowHeight } = useWindowDimensions();
 	const insets = useSafeAreaInsets();
-	const sheetHeight = getSheetContentHeight(windowHeight, insets.top, insets.bottom);
 
+	// Android presents sheets as an in-window transparentModal (see RootNavigator / #359),
+	// so we render the bottom-sheet look here: a dimmed, tap-to-dismiss backdrop above a
+	// bottom-anchored, rounded card.
+	if (Platform.OS === 'android') {
+		const cardHeight = windowHeight - insets.top - HEADER_HEIGHT;
+		return (
+			<View style={styles.androidRoot}>
+				<Pressable style={styles.backdrop} onPress={hideActiveSheet} />
+				<View style={[styles.androidCard, { height: cardHeight }]}>{children}</View>
+			</View>
+		);
+	}
+
+	const sheetHeight = getSheetContentHeight(windowHeight, insets.top, insets.bottom);
 	return <View style={[styles.frame, { height: sheetHeight }]}>{children}</View>;
 };
 
@@ -133,6 +157,20 @@ const Sheet = ({ id, children, ...screenProps }: SheetProps): ReactElement => {
 const styles = StyleSheet.create({
 	frame: {
 		backgroundColor: '#000000',
+	},
+	androidRoot: {
+		flex: 1,
+		justifyContent: 'flex-end',
+	},
+	backdrop: {
+		...StyleSheet.absoluteFill,
+		backgroundColor: 'rgba(0, 0, 0, 0.5)',
+	},
+	androidCard: {
+		backgroundColor: '#000000',
+		borderTopLeftRadius: 32,
+		borderTopRightRadius: 32,
+		overflow: 'hidden',
 	},
 	background: {
 		...StyleSheet.absoluteFill,

--- a/src/components/Sheet.tsx
+++ b/src/components/Sheet.tsx
@@ -1,6 +1,5 @@
 import React, { memo, ReactElement, ReactNode } from 'react';
 import {
-	Platform,
 	Pressable,
 	ScrollView,
 	StyleProp,
@@ -20,6 +19,7 @@ import { HEADER_HEIGHT } from './AppHeader.tsx';
 import type { SheetId } from '../sheets/types.ts';
 import { getSheetContentHeight } from '../sheets/sheetLayout.ts';
 import { hideActiveSheet } from '../sheets/sheetNavigation.tsx';
+import { shouldUseAndroidSheetFallback } from '../sheets/sheetPlatform.ts';
 import { ThemedView } from '../theme/components.ts';
 
 export type GradientType = 'none' | 'brand' | 'danger';
@@ -53,10 +53,7 @@ export const SheetFrame = ({ children }: SheetFrameProps): ReactElement => {
 	const { height: windowHeight } = useWindowDimensions();
 	const insets = useSafeAreaInsets();
 
-	// Android presents sheets as an in-window transparentModal (see RootNavigator / #359),
-	// so we render the bottom-sheet look here: a dimmed, tap-to-dismiss backdrop above a
-	// bottom-anchored, rounded card.
-	if (Platform.OS === 'android') {
+	if (shouldUseAndroidSheetFallback()) {
 		const cardHeight = windowHeight - insets.top - HEADER_HEIGHT;
 		return (
 			<View style={styles.androidRoot}>

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useMemo } from 'react';
 import { DefaultTheme, NavigationContainer, type Theme as NavigationTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { useWindowDimensions } from 'react-native';
+import { Platform, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import HomeScreen from '../screens/HomeScreen';
 import PubkyDetailScreen from '../screens/PubkyDetailScreen';
@@ -52,8 +52,21 @@ const RootNavigator = (): ReactElement => {
 		return getSheetDetent(windowHeight, insets.top, insets.bottom);
 	}, [insets.top, insets.bottom, windowHeight]);
 
-	const sheetScreenOptions: NativeStackNavigationOptions = useMemo(
-		() => ({
+	const sheetScreenOptions: NativeStackNavigationOptions = useMemo(() => {
+		// iOS: native formSheet works well. Android: react-native-screens' formSheet is
+		// presented in a separate window that is not drawn until a window relayout on some
+		// devices (MIUI / Redmi Note 11), so present an in-window transparentModal instead
+		// and render the bottom-sheet look ourselves in SheetFrame. See #359.
+		if (Platform.OS === 'android') {
+			return {
+				presentation: 'transparentModal',
+				animation: reducedMotionEnabled ? 'none' : 'slide_from_bottom',
+				contentStyle: {
+					backgroundColor: 'transparent',
+				},
+			};
+		}
+		return {
 			presentation: 'formSheet',
 			sheetAllowedDetents: [fixedSheetDetent],
 			sheetCornerRadius: 32,
@@ -61,9 +74,8 @@ const RootNavigator = (): ReactElement => {
 			contentStyle: {
 				backgroundColor: '#000000',
 			},
-		}),
-		[fixedSheetDetent],
-	);
+		};
+	}, [fixedSheetDetent, reducedMotionEnabled]);
 
 	const navTheme: NavigationTheme = useMemo(
 		() => ({

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useMemo } from 'react';
 import { DefaultTheme, NavigationContainer, type Theme as NavigationTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import type { NativeStackNavigationOptions } from '@react-navigation/native-stack';
-import { Platform, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import HomeScreen from '../screens/HomeScreen';
 import PubkyDetailScreen from '../screens/PubkyDetailScreen';
@@ -30,6 +30,7 @@ import AddPubkySheet from '../sheets/AddPubkySheet.tsx';
 import MigrateSheet from '../sheets/MigrateSheet.tsx';
 import LegacySunsetSheet from '../sheets/LegacySunsetSheet.tsx';
 import { useDeepLinkHandler } from '../hooks/useDeepLinkHandler.ts';
+import { shouldUseAndroidSheetFallback } from '../sheets/sheetPlatform.ts';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -53,11 +54,7 @@ const RootNavigator = (): ReactElement => {
 	}, [insets.top, insets.bottom, windowHeight]);
 
 	const sheetScreenOptions: NativeStackNavigationOptions = useMemo(() => {
-		// iOS: native formSheet works well. Android: react-native-screens' formSheet is
-		// presented in a separate window that is not drawn until a window relayout on some
-		// devices (MIUI / Redmi Note 11), so present an in-window transparentModal instead
-		// and render the bottom-sheet look ourselves in SheetFrame. See #359.
-		if (Platform.OS === 'android') {
+		if (shouldUseAndroidSheetFallback()) {
 			return {
 				presentation: 'transparentModal',
 				animation: reducedMotionEnabled ? 'none' : 'slide_from_bottom',
@@ -66,6 +63,7 @@ const RootNavigator = (): ReactElement => {
 				},
 			};
 		}
+
 		return {
 			presentation: 'formSheet',
 			sheetAllowedDetents: [fixedSheetDetent],

--- a/src/sheets/sheetNavigation.tsx
+++ b/src/sheets/sheetNavigation.tsx
@@ -118,3 +118,17 @@ export const showSheet = <TSheetId extends SheetId>(...args: ShowSheetArgs<TShee
 export const hideSheet = (id: SheetId): void => {
 	closeRootSheetRoute(sheetRouteById[id]);
 };
+
+const sheetRouteNameSet = new Set<string>(Object.values(sheetRouteById));
+
+/** Closes whichever sheet is currently on top of the root stack, if any. */
+export const hideActiveSheet = (): void => {
+	if (!navigationRef.isReady()) {
+		return;
+	}
+	const rootState = navigationRef.getRootState();
+	const top = rootState.routes[rootState.routes.length - 1];
+	if (top && sheetRouteNameSet.has(top.name)) {
+		closeRootSheetRoute(top.name as SheetRouteName);
+	}
+};

--- a/src/sheets/sheetPlatform.ts
+++ b/src/sheets/sheetPlatform.ts
@@ -1,0 +1,7 @@
+import { Platform } from 'react-native';
+
+const MAX_ANDROID_SHEET_FALLBACK_API_LEVEL = 33;
+
+export const shouldUseAndroidSheetFallback = (): boolean => {
+	return Platform.OS === 'android' && Platform.Version <= MAX_ANDROID_SHEET_FALLBACK_API_LEVEL;
+};

--- a/src/sheets/sheetPlatform.ts
+++ b/src/sheets/sheetPlatform.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-const MAX_ANDROID_SHEET_FALLBACK_API_LEVEL = 33;
+const MAX_ANDROID_SHEET_FALLBACK_API_LEVEL = 34;
 
 export const shouldUseAndroidSheetFallback = (): boolean => {
 	return Platform.OS === 'android' && Platform.Version <= MAX_ANDROID_SHEET_FALLBACK_API_LEVEL;


### PR DESCRIPTION
## Problem

Fixes #359. On some Android devices (e.g. **Redmi/Mi Note 11, MIUI/Android 13**), tapping **Add pubky** did nothing — and the same affected every sheet. Regression from #346 (native-stack form sheets).

The handler fires and the sheet's React content mounts, but react-native-screens presents the native `formSheet` in a **separate window** that isn't drawn until a **process-wide window relayout** (lock/unlock or app resume). This was reproduced and root-caused on the physical device; see the [investigation write-up on the issue](https://github.com/pubky/pubky-ring/issues/359#issuecomment-5357660662). It's device/OEM-specific — CI's `pixel_7` emulator and gesture-nav phones are unaffected.

Things that did **not** fix it (all tested on-device): detent clamp, upgrading react-native-screens to 4.27, bypassing Skia, `reset`→`push`, JS content nudge, `presentation: 'modal'`, `MainActivity.onCreate` default, a native module forcing an Activity-window relayout, and toggling `sheetAllowedDetents`.

## Fix

- **iOS: unchanged** — native `formSheet` works great there.
- **Android:** present sheets as an in-window `transparentModal` (a regular native-stack screen, which draws fine on this device) and render the bottom-sheet look ourselves in `SheetFrame`: a dimmed, tap-to-dismiss backdrop above a bottom-anchored, rounded card.

No new dependencies. All changes are `Platform.OS === 'android'`-guarded, so iOS behavior is byte-for-byte the same.

## Verified on a physical Redmi Note 11

- Add-pubky sheet **opens and renders** (previously blank until lock/unlock) ✅
- Bottom-sheet styling: rounded top, dimmed backdrop showing the home behind, drag indicator ✅
- **Backdrop tap** dismisses ✅
- **Hardware back** dismisses ✅
- **In-sheet sub-navigation** (Main → review) works ✅
- `tsc` + eslint clean on changed files ✅

https://github.com/user-attachments/assets/6429e0e9-71d1-4557-97fb-48d4f3c1c13d


## Follow-up / QA note

Input sheets (rename / import-mnemonic) rely on the app-wide `windowSoftInputMode=adjustPan` (unchanged) to keep focused inputs above the keyboard — worth a manual QA pass on Android, though behavior should match the rest of the app.

Related: #361 keeps the separate detent-range hardening.

