### PR TITLE
fix: stop logging secret-bearing input data

### DIFF
--- a/__tests__/inputRouter.test.ts
+++ b/__tests__/inputRouter.test.ts
@@ -14,6 +14,7 @@ import { handleDirectSignupAction, handleSignupAction } from '../src/utils/actio
 import { handleInviteAction } from '../src/utils/actions/inviteAction';
 import { handleSessionAction } from '../src/utils/actions/sessionAction';
 import { showSheet } from '../src/sheets/sheetNavigation';
+import { routeInputWithContext } from '../src/utils/inputHandlerUtils';
 
 jest.mock('../src/i18n', () => ({
 	__esModule: true,
@@ -27,6 +28,11 @@ jest.mock('@synonymdev/react-native-pubky', () => ({
 	parseAuthUrl: jest.fn(),
 	mnemonicPhraseToKeypair: jest.fn(),
 	getPublicKeyFromSecretKey: jest.fn(),
+}));
+
+jest.mock('@synonymdev/react-native-toast', () => ({
+	__esModule: true,
+	showToast: jest.fn(),
 }));
 
 jest.mock('../src/utils/errorHandler', () => ({
@@ -72,6 +78,11 @@ jest.mock('../src/utils/actions/sessionAction', () => ({
 jest.mock('../src/sheets/sheetNavigation', () => ({
 	__esModule: true,
 	showSheet: jest.fn(),
+}));
+
+jest.mock('../src/store/slices/pubkysSlice', () => ({
+	__esModule: true,
+	setDeepLink: jest.fn((payload: string) => ({ type: 'pubky/setDeepLink', payload })),
 }));
 
 const handleAuthActionMock = handleAuthAction as jest.MockedFunction<typeof handleAuthAction>;
@@ -314,6 +325,35 @@ describe('routeInput', () => {
 		expect(handleSessionActionMock).not.toHaveBeenCalled();
 
 		logSpy.mockRestore();
+	});
+});
+
+describe('routeInputWithContext', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('does not log raw deeplink input when routing fails', async () => {
+		handleMigrateActionMock.mockResolvedValue(err(new Error('Invalid migration parameters')));
+		const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+		const marker = 'TEST_H2_MARKER_not-a-real-secret';
+		const parsed: ParsedInput = {
+			action: InputAction.Migrate,
+			data: {
+				action: InputAction.Migrate,
+				params: { index: 1, total: 1, key: marker },
+			},
+			source: 'deeplink',
+			rawInput: `pubkyring://migrate?index=1%26total=1%26key=${marker}`,
+		};
+
+		await routeInputWithContext(parsed, undefined, 'deeplink', dispatch);
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			'Input routing error:',
+			expect.not.stringContaining(marker),
+		);
+		errorSpy.mockRestore();
 	});
 });
 

--- a/src/screens/AuthScanner.tsx
+++ b/src/screens/AuthScanner.tsx
@@ -14,7 +14,6 @@ import { InputAction, parseInput } from '../utils/inputParser.ts';
 import { actionRequiresNetwork, routeInput } from '../utils/inputRouter.ts';
 import { getAutoAuthFromStore, getIsOnline } from '../utils/store-helpers.ts';
 import { createConfirmAuthPayload } from '../utils/actions/authAction.ts';
-import i18n from '../i18n';
 
 const SHEET_ID = 'auth';
 
@@ -27,26 +26,18 @@ const AuthScanner = ({
 	const { pubky } = route.params;
 	const title = t('auth.authorize');
 
-	const showRouteError = useCallback((input: string, action: InputAction, error: unknown): void => {
-		const errorMsg = getErrorMessage(error, i18n.t('errors.unknownError'));
-		const debugInfo = JSON.stringify(
-			{
-				error: errorMsg,
-				input: input.substring(0, 100),
-				action,
-			},
-			null,
-			2,
-		);
+	const showRouteError = useCallback((action: InputAction, error: unknown): void => {
+		const errorMsg = getErrorMessage(error, t('errors.unknownError'));
+		const debugInfo = JSON.stringify({ error: errorMsg, action }, null, 2);
 
 		console.error('Auth scanner route error:', debugInfo);
 
 		showToast({
 			type: 'error',
-			title: i18n.t('common.error'),
+			title: t('common.error'),
 			description: errorMsg,
 		});
-	}, []);
+	}, [t]);
 
 	const handleInput = useCallback(
 		async (input: string, source: 'scan' | 'clipboard'): Promise<void> => {
@@ -63,8 +54,8 @@ const AuthScanner = ({
 				if (!connected) {
 					showToast({
 						type: 'error',
-						title: i18n.t('network.currentlyOffline'),
-						description: i18n.t('network.offlineDescription'),
+						title: t('network.currentlyOffline'),
+						description: t('network.offlineDescription'),
 						autoHide: false,
 					});
 					return;
@@ -77,7 +68,7 @@ const AuthScanner = ({
 					const result = await routeInput(parsed, { dispatch, pubky });
 
 					if (result.isErr()) {
-						showRouteError(input, parsed.action, result.error);
+						showRouteError(parsed.action, result.error);
 					}
 					return;
 				}
@@ -104,7 +95,7 @@ const AuthScanner = ({
 			const result = await routeInput(parsed, { dispatch, pubky });
 
 			if (result.isErr()) {
-				showRouteError(input, parsed.action, result.error);
+				showRouteError(parsed.action, result.error);
 			}
 		},
 		[dispatch, navigation, pubky, showRouteError, t],

--- a/src/utils/actions/sessionAction.ts
+++ b/src/utils/actions/sessionAction.ts
@@ -18,11 +18,7 @@ import { InputAction, SessionParams } from '../inputParser';
 import { ActionContext } from '../inputRouter';
 import { signInToHomeserver } from '../pubky';
 import { getErrorMessage } from '../errorHandler';
-import {
-	hasValidSessionCallbacks,
-	openXSuccessWithParams,
-	openXError,
-} from '../xCallback';
+import { hasValidSessionCallbacks, openXSuccessWithParams, openXError } from '../xCallback';
 import i18n from '../../i18n';
 import { showSheet } from '../../sheets/sheetNavigation';
 

--- a/src/utils/inputHandlerUtils.ts
+++ b/src/utils/inputHandlerUtils.ts
@@ -52,7 +52,6 @@ export const routeInputWithContext = async (
 		const debugInfo = JSON.stringify(
 			{
 				action: parsed.action,
-				rawInput: parsed.rawInput,
 				error: errorMessage,
 			},
 			null,

--- a/src/utils/inputRouter.ts
+++ b/src/utils/inputRouter.ts
@@ -159,7 +159,7 @@ export const routeInput = async (
 		}
 
 		if (isUnknownAction(data)) {
-			console.log('[InputRouter] Unknown input format:', data.params.rawData.substring(0, 100));
+			console.log('[InputRouter] Unknown input format');
 			return err(i18n.t('errors.unrecognizedFormat'));
 		}
 


### PR DESCRIPTION
## Summary

- remove raw deeplink input from routing error logs
- remove raw unknown input data from input router logs
- remove scanned/clipboard input snippets from auth scanner error logs
- add regression coverage for the H2 migration deeplink log leak

## Testing

- `yarn test __tests__/inputRouter.test.ts __tests__/xCallback.test.ts --runInBand`