### PR TITLE
fix(import): support migration QR from add pubky flow

### DIFF
--- a/.maestro/flows/migrate-keys.yaml
+++ b/.maestro/flows/migrate-keys.yaml
@@ -14,7 +14,14 @@ name: migrate-keys
       URL: "pubkyring://migrate?index=1&total=2&key=legal%20winner%20thank%20year%20wave%20sausage%20worth%20useful%20legal%20winner%20thank%20yellow"
 - extendedWaitUntil:
     visible:
-      id: PubkyBox--0
+      id: import-success-title
     timeout: 120000
+- assertVisible: "You successfully imported 2 key pairs."
+- tapOn:
+    id: ImportSuccessButton
+- extendedWaitUntil:
+    visible:
+      id: PubkyBox--0
+    timeout: 30000
 - assertVisible:
     id: PubkyBox--1

--- a/__tests__/AddPubkyImportSuccess.test.tsx
+++ b/__tests__/AddPubkyImportSuccess.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import AddPubkyImportSuccess from '../src/screens/AddPubkyImportSuccess';
+import { resetRootToHome, resetRootToHomeWithSheet } from '../src/sheets/sheetNavigation';
+
+jest.mock('../src/components/Sheet.tsx', () => {
+	const ReactMock = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		SheetScreen: ({ children }: { children?: React.ReactNode }) =>
+			ReactMock.createElement(View, null, children),
+	};
+});
+
+jest.mock('../src/components/Button.tsx', () => {
+	const ReactMock = require('react');
+	const { Pressable, Text } = require('react-native');
+
+	return {
+		__esModule: true,
+		default: ({ onPress, testID, text }: { onPress: () => void; testID?: string; text: string }) =>
+			ReactMock.createElement(
+				Pressable,
+				{ onPress, testID },
+				ReactMock.createElement(Text, null, text),
+			),
+	};
+});
+
+jest.mock('../src/components/PubkyProfile.tsx', () => {
+	const ReactMock = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		default: () => ReactMock.createElement(View, { testID: 'PubkyProfile' }),
+	};
+});
+
+jest.mock('../src/components/PubkyCard.tsx', () => {
+	const ReactMock = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		default: () => ReactMock.createElement(View, { testID: 'PubkyCard' }),
+	};
+});
+
+jest.mock('../src/theme/typography.ts', () => {
+	const ReactMock = require('react');
+	const { Text } = require('react-native');
+
+	return {
+		__esModule: true,
+		TextBaseM: ({ children }: { children?: React.ReactNode }) =>
+			ReactMock.createElement(Text, null, children),
+	};
+});
+
+jest.mock('react-redux', () => ({
+	__esModule: true,
+	useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock('react-i18next', () => ({
+	__esModule: true,
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+jest.mock('../src/store/selectors/pubkySelectors.ts', () => ({
+	__esModule: true,
+	getAllPubkys: jest.fn(() => ({})),
+	getPubky: jest.fn(() => undefined),
+	getPubkyCount: jest.fn(() => 1),
+}));
+
+jest.mock('../src/hooks/usePubkyHandlers.ts', () => ({
+	__esModule: true,
+	usePubkyHandlers: () => ({
+		onPubkyPress: jest.fn(),
+	}),
+}));
+
+jest.mock('../src/sheets/sheetNavigation', () => ({
+	__esModule: true,
+	hideSheet: jest.fn(),
+	resetRootToHome: jest.fn(),
+	resetRootToHomeWithSheet: jest.fn(),
+}));
+
+const resetRootToHomeMock = resetRootToHome as jest.MockedFunction<typeof resetRootToHome>;
+const resetRootToHomeWithSheetMock = resetRootToHomeWithSheet as jest.MockedFunction<
+	typeof resetRootToHomeWithSheet
+>;
+
+describe('AddPubkyImportSuccess', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('returns Home with the edit sheet for new imports', () => {
+		const pubky = 'pubky-new';
+		const { getByTestId } = render(
+			<AddPubkyImportSuccess
+				route={{ params: { pubky, isNewPubky: true } } as never}
+				navigation={{} as never}
+			/>,
+		);
+
+		fireEvent.press(getByTestId('ImportSuccessButton'));
+
+		expect(resetRootToHomeWithSheetMock).toHaveBeenCalledWith('edit-pubky', { pubky });
+		expect(resetRootToHomeMock).not.toHaveBeenCalled();
+	});
+
+	it('returns Home for migration imports', () => {
+		const { getByTestId } = render(
+			<AddPubkyImportSuccess
+				route={
+					{
+						params: {
+							isMigration: true,
+							pubkys: ['pubky-one'],
+							totalCount: 1,
+						},
+					} as never
+				}
+				navigation={{} as never}
+			/>,
+		);
+
+		fireEvent.press(getByTestId('ImportSuccessButton'));
+
+		expect(resetRootToHomeMock).toHaveBeenCalled();
+		expect(resetRootToHomeWithSheetMock).not.toHaveBeenCalled();
+	});
+});

--- a/__tests__/AddPubkyScanner.test.tsx
+++ b/__tests__/AddPubkyScanner.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { ok } from '@synonymdev/result';
+import AddPubkyScanner from '../src/screens/AddPubkyScanner';
+import { InputAction } from '../src/utils/inputParser';
+import { parseInput } from '../src/utils/inputParser';
+import { routeInput } from '../src/utils/inputRouter';
+import { showToast } from '@synonymdev/react-native-toast';
+import { resetMigrateAccumulator } from '../src/utils/actions/migrateAction';
+
+let mockScannerProps: {
+	onScan: (data: string) => Promise<void> | void;
+	onCopyClipboard: () => Promise<void>;
+};
+
+jest.mock('../src/components/Sheet.tsx', () => {
+	const ReactMock = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		SheetScreen: ({ children }: { children?: React.ReactNode }) =>
+			ReactMock.createElement(View, null, children),
+	};
+});
+
+jest.mock('../src/components/QRScannerContent.tsx', () => {
+	const ReactMock = require('react');
+	const { View } = require('react-native');
+
+	return {
+		__esModule: true,
+		default: (props: typeof mockScannerProps) => {
+			mockScannerProps = props;
+			return ReactMock.createElement(View, { testID: 'QRScannerContent' });
+		},
+	};
+});
+
+jest.mock('@react-navigation/native', () => ({
+	__esModule: true,
+	StackActions: {
+		replace: jest.fn((screen: string, params: unknown) => ({ type: 'replace', payload: { screen, params } })),
+	},
+}));
+
+jest.mock('react-redux', () => ({
+	__esModule: true,
+	useDispatch: () => jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+	__esModule: true,
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+jest.mock('@synonymdev/react-native-toast', () => ({
+	__esModule: true,
+	showToast: jest.fn(),
+}));
+
+jest.mock('../src/utils/clipboard', () => ({
+	__esModule: true,
+	readFromClipboard: jest.fn(),
+}));
+
+jest.mock('../src/utils/inputParser', () => ({
+	__esModule: true,
+	InputAction: {
+		Auth: 'auth',
+		Import: 'import',
+		Migrate: 'migrate',
+		Signup: 'signup',
+		DirectSignup: 'direct_signup',
+		Invite: 'invite',
+		Session: 'session',
+		HomeserverSignIn: 'homeserver_signin',
+		Unknown: 'unknown',
+	},
+	parseInput: jest.fn(),
+}));
+
+jest.mock('../src/utils/inputRouter', () => ({
+	__esModule: true,
+	routeInput: jest.fn(),
+}));
+
+jest.mock('../src/utils/actions/migrateAction', () => ({
+	__esModule: true,
+	handleMigrationScannerClose: jest.fn(),
+	resetMigrateAccumulator: jest.fn(),
+}));
+
+const parseInputMock = parseInput as jest.MockedFunction<typeof parseInput>;
+const routeInputMock = routeInput as jest.MockedFunction<typeof routeInput>;
+const showToastMock = showToast as jest.MockedFunction<typeof showToast>;
+const resetMigrateAccumulatorMock = resetMigrateAccumulator as jest.MockedFunction<
+	typeof resetMigrateAccumulator
+>;
+
+describe('AddPubkyScanner', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		routeInputMock.mockResolvedValue(ok({ success: true, action: InputAction.Migrate }));
+	});
+
+	it('routes migration QR frames from import mode', async () => {
+		const navigation = {
+			dispatch: jest.fn(),
+		};
+		const parsed = {
+			action: InputAction.Migrate,
+			data: {
+				action: InputAction.Migrate,
+				params: { index: 0, total: 2, key: 'encrypted-secret-key' },
+			},
+			source: 'scan',
+			rawInput: 'pubkyring://migrate?index=0&total=2&key=encrypted-secret-key',
+		} as const;
+		parseInputMock.mockResolvedValue(parsed);
+
+		render(<AddPubkyScanner navigation={navigation as never} route={{ params: { mode: 'import' } } as never} />);
+
+		await act(async () => {
+			await mockScannerProps.onScan(parsed.rawInput);
+		});
+
+		expect(resetMigrateAccumulatorMock).toHaveBeenCalled();
+		expect(routeInputMock).toHaveBeenCalledWith(parsed, {
+			dispatch: expect.any(Function),
+			setAddPubkyScreen: expect.any(Function),
+		});
+		expect(showToastMock).not.toHaveBeenCalled();
+	});
+});

--- a/__tests__/migrateAction.test.ts
+++ b/__tests__/migrateAction.test.ts
@@ -1,0 +1,128 @@
+import { err, ok } from '@synonymdev/result';
+import { InputAction } from '../src/utils/inputParser';
+import { handleMigrateAction, resetMigrateAccumulator } from '../src/utils/actions/migrateAction';
+import { hideActiveSheet, showSheet } from '../src/sheets/sheetNavigation';
+import { importPubky } from '../src/utils/pubky';
+import { mnemonicPhraseToKeypair } from '@synonymdev/react-native-pubky';
+
+jest.mock('../src/i18n', () => ({
+	__esModule: true,
+	default: {
+		t: (key: string) => key,
+	},
+}));
+
+jest.mock('@synonymdev/react-native-pubky', () => ({
+	__esModule: true,
+	mnemonicPhraseToKeypair: jest.fn(),
+}));
+
+jest.mock('@synonymdev/react-native-toast', () => ({
+	__esModule: true,
+	showToast: jest.fn(),
+}));
+
+jest.mock('../src/utils/pubky', () => ({
+	__esModule: true,
+	importPubky: jest.fn(),
+}));
+
+jest.mock('../src/utils/errorHandler', () => ({
+	__esModule: true,
+	getErrorMessage: (error: unknown, fallback: string) => {
+		if (error instanceof Error && error.message) return error.message;
+		if (typeof error === 'string' && error) return error;
+		return fallback;
+	},
+}));
+
+jest.mock('../src/sheets/sheetNavigation', () => ({
+	__esModule: true,
+	hideActiveSheet: jest.fn(),
+	showSheet: jest.fn(),
+}));
+
+const hideActiveSheetMock = hideActiveSheet as jest.MockedFunction<typeof hideActiveSheet>;
+const showSheetMock = showSheet as jest.MockedFunction<typeof showSheet>;
+const importPubkyMock = importPubky as jest.MockedFunction<typeof importPubky>;
+const mnemonicPhraseToKeypairMock = mnemonicPhraseToKeypair as jest.MockedFunction<
+	typeof mnemonicPhraseToKeypair
+>;
+
+describe('handleMigrateAction', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		resetMigrateAccumulator();
+		mnemonicPhraseToKeypairMock.mockResolvedValue(err(new Error('not a mnemonic')));
+		importPubkyMock.mockResolvedValue(ok('pubky-imported'));
+	});
+
+	it('closes the active scanner sheet for single-key migration imports', async () => {
+		const dispatch = jest.fn();
+
+		const result = await handleMigrateAction(
+			{
+				action: InputAction.Migrate,
+				params: {
+					index: 0,
+					total: 1,
+					key: 'encrypted-secret-key',
+				},
+			},
+			{ dispatch },
+		);
+
+		expect(result.isOk()).toBe(true);
+		expect(hideActiveSheetMock).toHaveBeenCalled();
+		expect(importPubkyMock).toHaveBeenCalledWith({
+			secretKey: 'encrypted-secret-key',
+			dispatch,
+			mnemonic: '',
+		});
+		expect(showSheetMock).toHaveBeenCalledWith('add-pubky', {
+			screen: 'ImportSuccess',
+			params: { isMigration: true, pubkys: ['pubky-imported'], totalCount: 1, failedCount: 0 },
+		});
+	});
+
+	it('shows compact import success for completed multi-key migrations', async () => {
+		const dispatch = jest.fn();
+		importPubkyMock.mockResolvedValueOnce(ok('pubky-one')).mockResolvedValueOnce(ok('pubky-two'));
+
+		const firstResult = await handleMigrateAction(
+			{
+				action: InputAction.Migrate,
+				params: {
+					index: 0,
+					total: 2,
+					key: 'encrypted-secret-key-one',
+				},
+			},
+			{ dispatch },
+		);
+		const secondResult = await handleMigrateAction(
+			{
+				action: InputAction.Migrate,
+				params: {
+					index: 1,
+					total: 2,
+					key: 'encrypted-secret-key-two',
+				},
+			},
+			{ dispatch },
+		);
+
+		expect(firstResult.isOk()).toBe(true);
+		expect(secondResult.isOk()).toBe(true);
+		expect(hideActiveSheetMock).toHaveBeenCalled();
+		expect(showSheetMock).toHaveBeenCalledWith('add-pubky', {
+			screen: 'ImportSuccess',
+			params: {
+				isMigration: true,
+				pubkys: ['pubky-one', 'pubky-two'],
+				totalCount: 2,
+				failedCount: 0,
+			},
+		});
+	});
+});

--- a/src/components/PubkyCard.tsx
+++ b/src/components/PubkyCard.tsx
@@ -46,6 +46,7 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		minHeight: 96,
+		paddingVertical: 16,
 	},
 	avatar: {
 		width: 48,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -91,8 +91,10 @@
 		"failed": "Import Failed",
 		"invalidRecoveryPhrase": "Invalid recovery phrase",
 		"pubkyImportedSuccessfully": "Pubky imported successfully",
-		"invalidData": "Invalid Data",
-		"invalidClipboardData": "Clipboard does not contain a valid recovery phrase or secret key",
+		"invalid": {
+			"title": "Invalid Data",
+			"description": "This does not contain a valid recovery phrase or secret key"
+		},
 		"importButton": "Import",
 		"pubkyImported": "Pubky Imported",
 		"pubkyReImported": "Pubky Re-Imported",
@@ -334,8 +336,15 @@
 	},
 	"migrate": {
 		"scanning": "Scanning for Keys",
+		"invalid": {
+			"title": "Invalid Migration Data",
+			"description": "This does not contain valid migration data. Scan or paste migration data generated from Settings > Show QR."
+		},
 		"successTitle": "Migration Complete",
 		"partialTitle": "Partial Migration Complete",
+		"importSuccess_one": "You successfully imported {{count}} key pair.",
+		"importSuccess_other": "You successfully imported {{count}} key pairs.",
+		"importPartialSuccess": "You successfully imported {{imported}} of {{total}} key pairs.",
 		"successMessage": "Successfully imported {{imported}} of {{total}} keys",
 		"partialSuccess": "Imported {{imported}} keys, {{failed}} failed",
 		"allFailed": "All keys failed to import"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -91,8 +91,10 @@
 		"failed": "Importación fallida",
 		"invalidRecoveryPhrase": "Frase de recuperación no válida",
 		"pubkyImportedSuccessfully": "Pubky importado con éxito",
-		"invalidData": "Datos no válidos",
-		"invalidClipboardData": "El portapapeles no contiene una frase de recuperación o una clave secreta válidas",
+		"invalid": {
+			"title": "Datos no válidos",
+			"description": "Esto no contiene una frase de recuperación o una clave secreta válidas"
+		},
 		"importButton": "Importar",
 		"pubkyImported": "Pubky Importado",
 		"pubkyReImported": "Pubky reimportado",
@@ -335,8 +337,15 @@
 	},
 	"migrate": {
 		"scanning": "Búsqueda de llaves",
+		"invalid": {
+			"title": "Datos de migración no válidos",
+			"description": "Esto no contiene datos de migración válidos. Escanee o pegue datos de migración generados desde Configuración > Mostrar QR."
+		},
 		"successTitle": "Migración completada",
 		"partialTitle": "Migración parcial Completa",
+		"importSuccess_one": "Ha importado correctamente {{count}} par de claves.",
+		"importSuccess_other": "Ha importado correctamente {{count}} pares de claves.",
+		"importPartialSuccess": "Ha importado correctamente {{imported}} de {{total}} pares de claves.",
 		"successMessage": "Importado con éxito {{imported}} de {{total}} claves",
 		"partialSuccess": "Importadas las claves {{imported}}, {{failed}} ha fallado",
 		"allFailed": "Falló la importación de todas las claves"

--- a/src/screens/AddPubkyImportSuccess.tsx
+++ b/src/screens/AddPubkyImportSuccess.tsx
@@ -1,16 +1,19 @@
 import React, { memo, ReactElement, useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { getPubky, getPubkyCount } from '../store/selectors/pubkySelectors.ts';
+import { getAllPubkys, getPubky, getPubkyCount } from '../store/selectors/pubkySelectors.ts';
 import { RootState } from '../store';
 import { SheetScreen } from '../components/Sheet.tsx';
 import PubkyProfile from '../components/PubkyProfile.tsx';
 import { TextBaseM } from '../theme/typography.ts';
 import Button from '../components/Button.tsx';
-import { hideSheet, showSheet } from '../sheets/sheetNavigation.tsx';
+import { hideSheet, resetRootToHome, resetRootToHomeWithSheet } from '../sheets/sheetNavigation.tsx';
 import type { AddPubkyStackParamList } from '../sheets/types.ts';
+import PubkyCard from '../components/PubkyCard.tsx';
+import { defaultPubkyState } from '../store/shapes/pubky.ts';
+import { usePubkyHandlers } from '../hooks/usePubkyHandlers.ts';
 
 const SHEET_ID = 'add-pubky';
 
@@ -18,31 +21,93 @@ const AddPubkyImportSuccess = ({
 	route,
 }: NativeStackScreenProps<AddPubkyStackParamList, 'ImportSuccess'>): ReactElement => {
 	const { t } = useTranslation();
+	const { onPubkyPress } = usePubkyHandlers();
 	const pubkyCount = useSelector(getPubkyCount);
-	const { isNewPubky, pubky } = route.params;
-	const pubkyData = useSelector((state: RootState) => getPubky(state, pubky));
+	const { params } = route;
+	const isMigration = params.isMigration === true;
+	const pubky = isMigration ? '' : params.pubky;
+	const isNewPubky = isMigration ? false : params.isNewPubky;
+	const pubkyData = useSelector((state: RootState) => (isMigration ? undefined : getPubky(state, pubky)));
+	const allPubkys = useSelector(getAllPubkys);
 
 	const onContinue = useCallback((): void => {
-		hideSheet(SHEET_ID);
-
-		if (!isNewPubky) {
+		if (isNewPubky) {
+			resetRootToHomeWithSheet('edit-pubky', { pubky });
 			return;
 		}
 
-		showSheet('edit-pubky', { pubky });
+		resetRootToHome();
 	}, [isNewPubky, pubky]);
 
-	const modalTitle = !isNewPubky ? t('import.pubkyReImported') : t('import.pubkyImported');
-	const description = !isNewPubky ? t('import.reImportSuccess') : t('import.importSuccess');
+	const onMigrationPubkyPress = useCallback(
+		(migratedPubky: string, index: number): void => {
+			hideSheet(SHEET_ID);
+			onPubkyPress(migratedPubky, index);
+		},
+		[onPubkyPress],
+	);
+
+	const modalTitle = isMigration || isNewPubky ? t('import.pubkyImported') : t('import.pubkyReImported');
+	const description = useMemo(() => {
+		if (isMigration) {
+			const importedCount = params.pubkys.length;
+			const failedCount = params.failedCount ?? Math.max(params.totalCount - importedCount, 0);
+			if (failedCount > 0) {
+				return t('migrate.importPartialSuccess', {
+					imported: importedCount,
+					total: params.totalCount,
+				});
+			}
+			return t('migrate.importSuccess', { count: importedCount });
+		}
+
+		return !isNewPubky ? t('import.reImportSuccess') : t('import.importSuccess');
+	}, [isMigration, isNewPubky, params, t]);
 
 	const data = useMemo(() => {
-		return { ...pubkyData, pubky, name: pubkyData.name || `pubky #${pubkyCount}` };
+		const resolvedPubkyData = pubkyData ?? defaultPubkyState;
+		return {
+			...resolvedPubkyData,
+			pubky,
+			name: resolvedPubkyData.name || `pubky #${pubkyCount}`,
+		};
 	}, [pubky, pubkyCount, pubkyData]);
+
+	const migrationPubkys = useMemo(() => {
+		if (!isMigration) {
+			return [];
+		}
+
+		return params.pubkys.map((migratedPubky, index) => {
+			const migratedPubkyData = allPubkys[migratedPubky];
+			return {
+				pubky: migratedPubky,
+				name: migratedPubkyData?.name || `pubky #${index + 1}`,
+			};
+		});
+	}, [allPubkys, isMigration, params]);
 
 	return (
 		<SheetScreen id={SHEET_ID} title={modalTitle} titleTestID="import-success-title" gradientType="brand">
 			<TextBaseM style={styles.message}>{description}</TextBaseM>
-			<PubkyProfile pubky={pubky} pubkyData={data} />
+
+			{isMigration ? (
+				<ScrollView style={styles.migrationList} contentContainerStyle={styles.migrationListContent}>
+					{migrationPubkys.map(({ pubky: migratedPubky, name }, index) => (
+						<TouchableOpacity
+							key={migratedPubky}
+							style={styles.migrationCard}
+							activeOpacity={0.7}
+							onPress={() => onMigrationPubkyPress(migratedPubky, index)}
+						>
+							<PubkyCard publicKey={migratedPubky} name={name} showChevron />
+						</TouchableOpacity>
+					))}
+				</ScrollView>
+			) : (
+				<PubkyProfile pubky={pubky} pubkyData={data} />
+			)}
+
 			<View style={styles.footer}>
 				<Button
 					text={t('common.continue')}
@@ -59,6 +124,15 @@ const AddPubkyImportSuccess = ({
 const styles = StyleSheet.create({
 	message: {
 		marginBottom: 24,
+	},
+	migrationList: {
+		flex: 1,
+	},
+	migrationListContent: {
+		paddingBottom: 24,
+	},
+	migrationCard: {
+		marginBottom: 16,
 	},
 	footer: {
 		marginTop: 'auto',

--- a/src/screens/AddPubkyScanner.tsx
+++ b/src/screens/AddPubkyScanner.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactElement, useCallback } from 'react';
+import React, { memo, ReactElement, useCallback, useEffect } from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { StackActions } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
@@ -10,6 +10,7 @@ import { readFromClipboard } from '../utils/clipboard';
 import { parseInput, InputAction } from '../utils/inputParser';
 import { routeInput } from '../utils/inputRouter';
 import type { AddPubkySheetScreenParams, AddPubkyStackParamList } from '../sheets/types.ts';
+import { handleMigrationScannerClose, resetMigrateAccumulator } from '../utils/actions/migrateAction.ts';
 
 const SHEET_ID = 'add-pubky';
 
@@ -21,6 +22,18 @@ const AddPubkyScanner = ({
 	const dispatch = useDispatch();
 	const { mode } = route.params;
 	const title = mode === 'import' ? t('import.title') : t('home.scanQR');
+
+	useEffect(() => {
+		if (mode !== 'import') {
+			return;
+		}
+
+		resetMigrateAccumulator();
+
+		return (): void => {
+			handleMigrationScannerClose();
+		};
+	}, [mode]);
 
 	const replaceRoute = useCallback(
 		(nextRoute: AddPubkySheetScreenParams): void => {
@@ -39,7 +52,7 @@ const AddPubkyScanner = ({
 				);
 			}
 
-			return action === InputAction.Import;
+			return action === InputAction.Import || action === InputAction.Migrate;
 		},
 		[mode],
 	);
@@ -56,8 +69,8 @@ const AddPubkyScanner = ({
 
 		showToast({
 			type: 'error',
-			title: t('import.invalidData'),
-			description: t('import.invalidClipboardData'),
+			title: t('import.invalid.title'),
+			description: t('import.invalid.description'),
 		});
 	}, [mode, t]);
 

--- a/src/screens/MigrateScanner.tsx
+++ b/src/screens/MigrateScanner.tsx
@@ -9,11 +9,7 @@ import { readFromClipboard } from '../utils/clipboard.ts';
 import { checkNetworkConnection } from '../utils/helpers.ts';
 import { InputAction, parseInput } from '../utils/inputParser.ts';
 import { actionRequiresNetwork, routeInput } from '../utils/inputRouter.ts';
-import {
-	handleMigrationScannerClose,
-	resetMigrateAccumulator,
-	setOnMigrationComplete,
-} from '../utils/actions/migrateAction.ts';
+import { handleMigrationScannerClose, resetMigrateAccumulator } from '../utils/actions/migrateAction.ts';
 import { getIsOnline } from '../utils/store-helpers.ts';
 import i18n from '../i18n';
 
@@ -29,7 +25,6 @@ const MigrateScanner = (): ReactElement => {
 
 		return (): void => {
 			handleMigrationScannerClose();
-			setOnMigrationComplete(null);
 		};
 	}, []);
 
@@ -41,8 +36,8 @@ const MigrateScanner = (): ReactElement => {
 				hideSheet(SHEET_ID);
 				showToast({
 					type: 'error',
-					title: t('import.invalidData'),
-					description: t('import.invalidClipboardData'),
+					title: t('migrate.invalid.title'),
+					description: t('migrate.invalid.description'),
 				});
 				return;
 			}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -20,7 +20,6 @@ import { resetPubkys } from '../store/slices/pubkysSlice.ts';
 import { useTranslation } from 'react-i18next';
 import { showSheet } from '../sheets/sheetNavigation.tsx';
 import { TextBaseB, TextBaseM, TextSmM, TextXsM } from '../theme/typography';
-import { setOnMigrationComplete } from '../utils/actions/migrateAction.ts';
 import SafeAreaView from '../components/SafeAreaView.tsx';
 import { Qrcode, Scan } from '../icons/index.ts';
 
@@ -91,17 +90,8 @@ const SettingsScreen = ({ navigation, route }: Props): ReactElement => {
 	}, [dispatch, enableAutoAuth]);
 
 	const handleScanQRPress = useCallback(() => {
-		// Reset to Home when migration completes (prevents swipe-back to Settings)
-		setOnMigrationComplete(() => {
-			navigation.reset({
-				index: 0,
-				routes: [{ name: 'Home' }],
-			});
-			setOnMigrationComplete(null); // Clean up
-		});
-
 		showSheet('migrate', { screen: 'Scanner' });
-	}, [navigation]);
+	}, []);
 
 	return (
 		<SafeAreaView style={styles.container} edges={['bottom']}>

--- a/src/sheets/sheetNavigation.tsx
+++ b/src/sheets/sheetNavigation.tsx
@@ -119,6 +119,41 @@ export const hideSheet = (id: SheetId): void => {
 	closeRootSheetRoute(sheetRouteById[id]);
 };
 
+const resetRootRoutes = (
+	routes: Array<{
+		name: keyof RootStackParamList;
+		params?: RootStackParamList[keyof RootStackParamList];
+	}>,
+): void => {
+	if (!navigationRef.isReady()) {
+		return;
+	}
+
+	navigationRef.dispatch(
+		CommonActions.reset({
+			index: routes.length - 1,
+			routes,
+		}),
+	);
+};
+
+export const resetRootToHome = (): void => {
+	resetRootRoutes([{ name: 'Home' }]);
+};
+
+export const resetRootToHomeWithSheet = <TSheetId extends SheetId>(
+	...args: ShowSheetArgs<TSheetId>
+): void => {
+	const [id, params] = args;
+	resetRootRoutes([
+		{ name: 'Home' },
+		{
+			name: sheetRouteById[id],
+			params,
+		},
+	]);
+};
+
 const sheetRouteNameSet = new Set<string>(Object.values(sheetRouteById));
 
 /** Closes whichever sheet is currently on top of the root stack, if any. */

--- a/src/sheets/types.ts
+++ b/src/sheets/types.ts
@@ -67,6 +67,14 @@ export interface EditPubkySheetParams {
 export type AddPubkyImportSuccessParams = {
 	pubky: string;
 	isNewPubky: boolean;
+	isMigration?: false;
+};
+
+export type AddPubkyMigrationSuccessParams = {
+	isMigration: true;
+	pubkys: string[];
+	totalCount: number;
+	failedCount?: number;
 };
 
 export type AddPubkyScannerParams = {
@@ -83,7 +91,7 @@ export type AddPubkyStackParamList = {
 	ImportOptions: undefined;
 	ImportFileScreen: ImportFileScreenParams;
 	ImportMnemonic: undefined;
-	ImportSuccess: AddPubkyImportSuccessParams;
+	ImportSuccess: AddPubkyImportSuccessParams | AddPubkyMigrationSuccessParams;
 };
 
 export type AddPubkySheetScreenParams = {

--- a/src/utils/actions/migrateAction.ts
+++ b/src/utils/actions/migrateAction.ts
@@ -9,13 +9,11 @@
 import { Result, ok, err } from '@synonymdev/result';
 import { mnemonicPhraseToKeypair } from '@synonymdev/react-native-pubky';
 import { showToast } from '@synonymdev/react-native-toast';
-import { hideSheet, showSheet } from '../../sheets/sheetNavigation.tsx';
+import { hideActiveSheet, showSheet } from '../../sheets/sheetNavigation.tsx';
 import { InputAction, MigrateParams } from '../inputParser';
 import { ActionContext } from '../inputRouter';
 import { importPubky } from '../pubky';
 import { getErrorMessage } from '../errorHandler';
-import { getPubkyKeys } from '../../store/selectors/pubkySelectors';
-import { getStore } from '../store-helpers';
 import i18n from '../../i18n';
 
 type MigrateActionData = {
@@ -42,8 +40,8 @@ let importedIndices: Set<number> = new Set();
 let expectedTotal: number | null = null;
 let successfulImports = 0;
 let failedImports = 0;
+let importedPubkys: string[] = [];
 let migrationCancelled = false;
-let onMigrationCompleteCallback: (() => void) | null = null;
 
 // Store import promises for parallel processing
 let importPromises: Map<number, Promise<Result<string>>> = new Map();
@@ -87,11 +85,13 @@ const notifyProgressListeners = (): void => {
 	progressListeners.forEach(listener => listener(progress));
 };
 
-/**
- * Sets a callback to be called when migration completes (all frames imported)
- */
-export const setOnMigrationComplete = (callback: (() => void) | null): void => {
-	onMigrationCompleteCallback = callback;
+const closeMigrationScannerAndShowSuccess = (
+	pubkys: string[],
+	totalCount: number,
+	successCount: number,
+): void => {
+	hideActiveSheet();
+	showMigrationSuccess(pubkys, totalCount, successCount);
 };
 
 /**
@@ -102,6 +102,7 @@ export const resetMigrateAccumulator = (): void => {
 	expectedTotal = null;
 	successfulImports = 0;
 	failedImports = 0;
+	importedPubkys = [];
 	migrationCancelled = false;
 	importPromises = new Map();
 	notifyProgressListeners();
@@ -134,20 +135,12 @@ const completeMigration = (): void => {
 	// Capture counts before resetting
 	const finalSuccessCount = successfulImports;
 	const finalTotalCount = importedIndices.size;
+	const finalImportedPubkys = importedPubkys.filter(Boolean);
 
 	// Reset state immediately
 	resetMigrateAccumulator();
 
-	// Close camera now that all keys are imported
-	hideSheet('migrate');
-
-	// Show completion summary with captured values
-	showMigrationSummary(finalSuccessCount, finalTotalCount);
-
-	// Notify and clear completion callback to prevent stale callbacks on consecutive migrations
-	const callback = onMigrationCompleteCallback;
-	onMigrationCompleteCallback = null;
-	callback?.();
+	closeMigrationScannerAndShowSuccess(finalImportedPubkys, finalTotalCount, finalSuccessCount);
 };
 
 /**
@@ -173,7 +166,6 @@ export const handleMigrateAction = async (
 	try {
 		// Single key migration - import and show success UI
 		if (total === 1) {
-			hideSheet('migrate');
 			return await importSingleKey(key, dispatch);
 		}
 
@@ -209,6 +201,7 @@ export const handleMigrateAction = async (
 			// Update progress when this individual import completes
 			if (result.isOk()) {
 				successfulImports++;
+				importedPubkys[index] = result.value;
 			} else {
 				failedImports++;
 			}
@@ -246,7 +239,6 @@ export const handleMigrateAction = async (
  * Imports a single key (for single-key migrations)
  */
 const importSingleKey = async (key: string, dispatch: ActionContext['dispatch']): Promise<Result<string>> => {
-	const currentPubkys = getPubkyKeys(getStore());
 	const { secretKey, mnemonic } = await parseKeyInput(key);
 
 	const importRes = await importPubky({
@@ -266,12 +258,8 @@ const importSingleKey = async (key: string, dispatch: ActionContext['dispatch'])
 	}
 
 	const importedPubky = importRes.value;
-	const isNewPubky = !currentPubkys.includes(importedPubky);
 
-	showSheet('add-pubky', {
-		screen: 'ImportSuccess',
-		params: { pubky: importedPubky, isNewPubky },
-	});
+	closeMigrationScannerAndShowSuccess([importedPubky], 1, 1);
 
 	return ok(importedPubky);
 };
@@ -347,4 +335,25 @@ const showMigrationSummary = (successCount: number, totalCount: number, isPartia
 			description: i18n.t('migrate.allFailed'),
 		});
 	}
+};
+
+const showMigrationSuccess = (
+	pubkys: string[],
+	totalCount: number,
+	successCount: number,
+): void => {
+	if (pubkys.length === 0) {
+		showMigrationSummary(successCount, totalCount);
+		return;
+	}
+
+	showSheet('add-pubky', {
+		screen: 'ImportSuccess',
+		params: {
+			isMigration: true,
+			pubkys,
+			totalCount,
+			failedCount: Math.max(totalCount - pubkys.length, 0),
+		},
+	});
 };


### PR DESCRIPTION
## Summary

- Allow the Add Pubky import scanner to accept migration QR frames
- Show the shared import success screen after migration imports from both Add Pubky and Settings scan flows
- Render migrated pubkys as compact tappable PubkyCards, preserving migration frame order
- Keep migration completion ordering consistent so Settings navigation reset does not dismiss the success sheet
- Add source-neutral invalid import/migration toast copy
- Update the migrate-keys Maestro flow to assert the new success screen

https://github.com/user-attachments/assets/18011d61-b008-46d3-920b-0c182d9a2dbe

## Testing

- yarn test __tests__/AddPubkyScanner.test.tsx __tests__/migrateAction.test.ts __tests__/inputRouter.test.ts --runInBand
- yarn typecheck
- yarn lint