### PR TITLE
v1.17 universal APK crashes on launch on x86_64: universal APK is not ABI-filtered (#358)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,6 +107,18 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 24
         versionName "1.17"
+
+        // splits.abi above only picks which ABIs are compiled from source and which
+        // per-ABI APKs are emitted; the universal APK packages every ABI still in the
+        // merged jniLibs dir, including x86/x86_64 libs that third-party AARs ship
+        // prebuilt. It then advertised ABIs it had none of our from-source libs for
+        // (libappmodules.so, libNitroMmkv.so, ...) and died on the first dlopen.
+        // packaging.jniLibs.excludes cannot do this job, because AGP resolves
+        // pickFirsts before excludes and the React Native plugin pick-firsts
+        // libreactnative.so, libhermesvm.so and friends for every ABI.
+        ndk {
+            abiFilters(*reactNativeArchitectures())
+        }
     }
 
     signingConfigs {


### PR DESCRIPTION
Closes #358

Set defaultConfig.ndk.abiFilters from reactNativeArchitectures so release APKs stop packaging x86/x86_64 libs the build never produced.

The universal release APK carried a half-populated lib/x86_64 (only the 16 libs third-party AARs ship prebuilt, none of the 12 built from source), so any x86_64 device selected x86_64 as its primary ABI and died on the first dlopen. splits.abi only governs what gets compiled and which per-ABI APKs are emitted, not what the universal APK packages. The remedy suggested in the issue, packaging.jniLibs.excludes, does not work: I measured it stripping 10 of the 16 x86_64 libs and leaving libreactnative.so, libhermesvm.so, libhermestooling.so, libjsi.so, libfbjni.so and libc++_shared.so, because AGP resolves pickFirsts before excludes and the React Native Gradle plugin pick-firsts exactly those (NdkConfiguratorUtils.kt). An APK still carrying those 6 would keep x86_64 as the primary ABI and keep crashing.

## What changed

- `android/app/build.gradle` sets `defaultConfig.ndk.abiFilters(*reactNativeArchitectures())`, so packaging drops every ABI the build does not target, in the universal APK and the splits alike, and the CI `-PreactNativeArchitectures=x86_64` override still selects the right one.
- Comment records why `packaging.jniLibs.excludes` is not the fix, since that is what the next person will reach for.

## How to test

- `cd android && ./gradlew :app:packageRelease` (default `reactNativeArchitectures=armeabi-v7a,arm64-v8a`), then `unzip -l app/build/outputs/apk/release/app-universal-release.apk | grep lib/`: the universal APK now holds 28 arm64-v8a plus 28 armeabi-v7a libs and nothing else, and each split APK holds 28. Before the change, the same command on an arm64-only build gave a universal APK with 6 x86, 6 x86_64 and stray armeabi/mips/mips64 entries.
- Single-ABI override: `./gradlew :app:packageRelease -PreactNativeArchitectures=arm64-v8a` yields a universal APK with only 28 arm64-v8a libs. AGP accepted abiFilters alongside splits.abi in both runs (Gradle 9.3.1, JDK 21).
- To reproduce the pickFirsts finding: `./gradlew :app:mergeReleaseNativeLibs -PreactNativeArchitectures=arm64-v8a` and count `app/build/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib/x86_64` - 16 unpatched, 6 with the packaging.jniLibs.excludes approach, 0 with this change.